### PR TITLE
Improve Caching when using Redis

### DIFF
--- a/src/web/CareLeavers.Web/Caching/DistributedCacheExtensions.cs
+++ b/src/web/CareLeavers.Web/Caching/DistributedCacheExtensions.cs
@@ -74,7 +74,6 @@ public static class DistributedCacheExtensions
             if (ex is not (RedisConnectionException or RedisCommandException)) throw;
             
             // Otherwise, let's log that we can't connect and run the task direct
-            // TODO: Log to App Insights?
             Log.Logger.Error(ex, "Redis Error");
 
             // Go and fetch directly from source

--- a/src/web/CareLeavers.Web/Caching/DistributedCacheExtensions.cs
+++ b/src/web/CareLeavers.Web/Caching/DistributedCacheExtensions.cs
@@ -1,14 +1,15 @@
 using System.Text;
 using Microsoft.Extensions.Caching.Distributed;
 using Newtonsoft.Json;
+using Serilog;
+using StackExchange.Redis;
 
 namespace CareLeavers.Web.Caching;
 
 public static class DistributedCacheExtensions
 {
-    private static DistributedCacheEntryOptions DefaultCacheOptions { get; set; } =
+    public static DistributedCacheEntryOptions DefaultCacheOptions { get; set; } =
         new DistributedCacheEntryOptions()
-            .SetSlidingExpiration(TimeSpan.FromMinutes(30))
             .SetAbsoluteExpiration(TimeSpan.FromHours(1));
     
     public static Task SetAsync<T>(this IDistributedCache cache, string key, T value)
@@ -46,22 +47,41 @@ public static class DistributedCacheExtensions
         Func<Task<T>> task, 
         DistributedCacheEntryOptions? options = null)
     {
-        if (options == null)
+        try
         {
-            options = DefaultCacheOptions;
-        }
-        
-        if (cache.TryGetValue(key, out T? value) && value is not null)
-        {
+            if (options == null)
+            {
+                options = DefaultCacheOptions;
+            }
+
+            if (cache.TryGetValue(key, out T? value) && value is not null)
+            {
+                return value;
+            }
+
+            value = await task();
+
+            if (value is not null)
+            {
+                await cache.SetAsync<T>(key, value, options);
+            }
+            
             return value;
         }
-        
-        value = await task();
-        
-        if (value is not null)
+        catch (Exception ex)
         {
-            await cache.SetAsync<T>(key, value, options);
+            // If our error isn't a redis one, throw it
+            if (ex is not (RedisConnectionException or RedisCommandException)) throw;
+            
+            // Otherwise, let's log that we can't connect and run the task direct
+            // TODO: Log to App Insights?
+            Log.Logger.Error(ex, "Redis Error");
+
+            // Go and fetch directly from source
+            return await task();;
+
         }
-        return value;
+
+        
     }
 }

--- a/src/web/CareLeavers.Web/Configuration/CachingOptions.cs
+++ b/src/web/CareLeavers.Web/Configuration/CachingOptions.cs
@@ -13,4 +13,6 @@ public class CachingOptions
     public string Type { get; set; } = string.Empty;
     
     public string? ConnectionString { get; init; }
+
+    public TimeSpan Duration { get; set; } = TimeSpan.FromDays(30);
 }

--- a/src/web/CareLeavers.Web/Program.cs
+++ b/src/web/CareLeavers.Web/Program.cs
@@ -17,6 +17,7 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 using OpenTelemetry.Trace;
 using Serilog;
+using DistributedCacheExtensions = CareLeavers.Web.Caching.DistributedCacheExtensions;
 
 Log.Logger = new LoggerConfiguration()
     .ConfigureLogging(Environment.GetEnvironmentVariable("ApplicationInsights__ConnectionString"))
@@ -151,6 +152,9 @@ try
     {
         builder.Services.AddSingleton<IDistributedCache, CacheDisabledDistributedCache>();
     }
+
+    DistributedCacheExtensions.DefaultCacheOptions.SetAbsoluteExpiration(
+        cachingOptions?.Duration ?? TimeSpan.FromDays(30));
     
     #endregion
     

--- a/src/web/CareLeavers.Web/appsettings.json
+++ b/src/web/CareLeavers.Web/appsettings.json
@@ -20,7 +20,8 @@
   },
   "Caching": {
     "Type": "Memory",
-    "ConnectionString": ""
+    "ConnectionString": "",
+    "Duration": "30.00:00:00"
   },
   "ApplicationInsights": {
     "ConnectionString": ""

--- a/src/web/README.md
+++ b/src/web/README.md
@@ -11,4 +11,5 @@ You will need:
 4. Ensure gulp is installed globally ```npm install -g gulp```
 5. Run the "dev" gulp task to build the front end assets (Either from Rider or ```gulp dev``` in the command line).
 6. Add contentful keys to your .NET user secrets
-7. Run the web project
+7. If using Redis as a distributed cache, ensure you have set the connection string (including short timeout values), eg: `redis-host:6379,ConnectTimeout=250,AsyncTimeout=250,SyncTimeout=250`
+8. Run the web project


### PR DESCRIPTION
Updated to fix the following:
- Cache duration is now set in configuration
- Will bypass cache in the event Redis is down
- Logs error
- Non-Redis errors will still throw an exception

### Note
**Connection timeout, sync timeout, and async timeout must be set to low values to ensure the site doesn't crawl to a halt.**

It might be worth looking into whether to track the number of redis exceptions and getting the site to disable redis for x hours on a sliding scale and log further