### PR TITLE
Fix up Contentful Migration Tool

### DIFF
--- a/src/contentful/CareLeavers.ContentfulMigration/Migrations/0020-add-migration-name.cjs
+++ b/src/contentful/CareLeavers.ContentfulMigration/Migrations/0020-add-migration-name.cjs
@@ -1,0 +1,19 @@
+module.exports = function (migration) {
+    const migrationContent = migration
+        .editContentType("migrationTracker")
+        .displayField("name");
+
+    migrationContent
+        .createField("name")
+        .name("Name")
+        .type("Symbol")
+        .localized(false)
+        .required(true)
+        .validations([])
+        .disabled(false)
+        .omitted(false)
+
+    migrationContent
+        .moveField('name').toTheTop();
+    
+};

--- a/src/contentful/CareLeavers.ContentfulMigration/Program.cs
+++ b/src/contentful/CareLeavers.ContentfulMigration/Program.cs
@@ -155,7 +155,9 @@ if (anyMigrationsHaveApplied)
         },
         Fields = new
         {
-            name = "Migration Tracker - DO NOT DELETE",
+            name = new Dictionary<string, dynamic> {
+                ["en-US"] = "Migration Tracker - DO NOT DELETE"
+            },
             migrations = new Dictionary<string, dynamic>
             {
                 ["en-US"] = migrationTracker.Migrations


### PR DESCRIPTION
Updated to fix the migration tool to ensure that the migration tracker itself has a name field and renames itself upon run to ensure nobody deletes it