### PR TITLE
Contentful Model Changes

### DIFF
--- a/src/contentful/CareLeavers.ContentfulMigration/Migrations/0021-update-grid-and-page-models.cjs
+++ b/src/contentful/CareLeavers.ContentfulMigration/Migrations/0021-update-grid-and-page-models.cjs
@@ -1,0 +1,15 @@
+module.exports = function (migration) {
+    const grid = migration
+        .editContentType("grid");
+
+    grid
+        .deleteField("cssClass"); // Remove redundant field
+    
+    const page = migration
+        .editContentType("page");
+
+    page
+        .moveField("contentsHeadings").afterField("showContentsBlock") // Move to after show contents block
+        .changeFieldControl("contentsHeadings", "builtin", "checkbox"); // Change to checklist
+    
+};

--- a/src/contentful/CareLeavers.ContentfulMigration/Migrations/0021-update-grid-and-page-models.cjs
+++ b/src/contentful/CareLeavers.ContentfulMigration/Migrations/0021-update-grid-and-page-models.cjs
@@ -10,6 +10,8 @@ module.exports = function (migration) {
 
     page
         .moveField("contentsHeadings").afterField("showContentsBlock") // Move to after show contents block
+        
+    page
         .changeFieldControl("contentsHeadings", "builtin", "checkbox"); // Change to checklist
     
 };

--- a/src/contentful/CareLeavers.ContentfulMigration/Migrations/0022-extra-model-fixes.cjs
+++ b/src/contentful/CareLeavers.ContentfulMigration/Migrations/0022-extra-model-fixes.cjs
@@ -6,6 +6,13 @@ module.exports = function (migration) {
         .deleteField("position"); // Remove redundant field
 
     card
+        .editField('types')
+        .items({
+            type: "Symbol",
+            validations: [{ in: ["Guide", "Support"] }],
+        })
+    
+    card
         .changeFieldControl("types", "builtin", "checkbox");
 
     const grid = migration

--- a/src/contentful/CareLeavers.ContentfulMigration/Migrations/0022-extra-model-fixes.cjs
+++ b/src/contentful/CareLeavers.ContentfulMigration/Migrations/0022-extra-model-fixes.cjs
@@ -1,0 +1,26 @@
+module.exports = function (migration) {
+    const card = migration
+        .editContentType("card");
+
+    card
+        .deleteField("position"); // Remove redundant field
+
+    card
+        .changeFieldControl("types", "builtin", "checkbox");
+
+    const grid = migration
+        .editContentType("grid");
+
+    grid
+        .deleteField("showTitle"); // Remove redundant field
+    
+    const page = migration
+        .editContentType("page");
+        
+    page
+        .changeFieldControl("slug", "builtin", "slugEditor", {
+            helpText: "Unique URL for the site - may have sections in front of it, for example \"find-housing\" will allow access via /find-housing, but also possibly /guides/find-housing",
+            trackingFieldId: "title"
+    }); // Change to checklist
+    
+};

--- a/src/web/CareLeavers.Web/Models/Content/Grid.cs
+++ b/src/web/CareLeavers.Web/Models/Content/Grid.cs
@@ -11,8 +11,6 @@ public class Grid : ContentfulContent
     
     public GridType? GridType { get; set; }
     
-    public bool ShowTitle { get; set; }
-    
     public List<IContent>? Content { get; set; }
 
     public string? CssClass { get; set; } = "govuk-grid-column-full";

--- a/src/web/CareLeavers.Web/Views/Shared/Grid.cshtml
+++ b/src/web/CareLeavers.Web/Views/Shared/Grid.cshtml
@@ -8,10 +8,6 @@
     {
         case GridType.Cards:
             <section class="dfe-section govuk-!-margin-top-5">
-                @if (Model.ShowTitle)
-                {
-                    <h2 class="govuk-heading-l" id="@TagBuilder.CreateSanitizedId(Model.Title, "-")">@Model.Title</h2>
-                }
                 @if (Model.Content != null && Model.Content.Any())
                 {
                     <div class="dfe-grid-container dfe-grid-container--wider govuk-!-margin-top-5">
@@ -27,12 +23,6 @@
 
         case GridType.AlternatingImageAndText:
             <section class="dfe-section alternating-image-text">
-                @if (Model.ShowTitle)
-                {
-                    <h2 class="govuk-heading-l" id="@TagBuilder.CreateSanitizedId(Model.Title, "-")">@Model.Title</h2>
-                }
-
-
                 @if (Model.Content != null && Model.Content.Any())
                 {
                     var position = -1;
@@ -68,11 +58,6 @@
         
         case GridType.ExternalLinks:
             <section class="dfe-section govuk-!-margin-top-5">
-        
-                @if (Model.ShowTitle)
-                {
-                    <h2 class="govuk-heading-l" id="@TagBuilder.CreateSanitizedId(Model.Title, "-")">@Model.Title</h2>
-                }
                 @if (Model.Content != null)
                 {
                     @foreach (var content in Model.Content)

--- a/src/web/tests/CareLeavers.Integration.Tests/Tests/SnapshotTests/Output/ComponentTest.html
+++ b/src/web/tests/CareLeavers.Integration.Tests/Tests/SnapshotTests/Output/ComponentTest.html
@@ -166,7 +166,6 @@
 							</section>
 						</div>
 						<section class="dfe-section govuk-!-margin-top-5">
-							<h2 class="govuk-heading-l" id="External-Agency">External Agency</h2>
 							<div class="dfe-box box-ext">
 								<div class="box-icon">
 								</div>


### PR DESCRIPTION
Updated models as per recent changes, plus discarded some fields that had been created by mistake:
- Grid
  - Removed css class field
  - Removed show title from grid
- Page 
  - Show contents headings as checkboxes
  - Changed slug to do the following:
    - Use the slug edtior
    - Determine slug from page title
- Card
  - Change types to show as a checkbox
  - Removed redundant "Position" field

Titles for grids should now be entered as part of the content block containing the grid