### PR TITLE
ShareThis and Printing

### DIFF
--- a/src/web/CareLeavers.Web/Models/Content/Page.cs
+++ b/src/web/CareLeavers.Web/Models/Content/Page.cs
@@ -29,8 +29,8 @@ public class Page : ContentfulContent
     public bool ShowContentsBlock { get; set; } = false;
     
     public HeadingType[] ContentsHeadings { get; set; } = [ ];
-    
-    public bool ShowLastUpdated { get; set; }
+
+    public bool ShowLastUpdated { get; set; } = true;
     
     public bool ShowShareThis { get; set; }
     

--- a/src/web/CareLeavers.Web/TagHelpers/GDSContentfulContentsTagHelper.cs
+++ b/src/web/CareLeavers.Web/TagHelpers/GDSContentfulContentsTagHelper.cs
@@ -60,7 +60,7 @@ public class GDSContentfulContentsTagHelper : TagHelper
             {
                 TagBuilder item = new TagBuilder("li");
                 item.AddCssClass("govuk-body-s");
-                item.InnerHtml.AppendHtml($"<a href=\"#{heading.Id}\">{heading.InnerHtml}</a>");
+                item.InnerHtml.AppendHtml($"<a href=\"#{heading.Id}\" class=\"govuk-link\">{heading.InnerHtml}</a>");
                 list.InnerHtml.AppendHtml(item);
             }
 

--- a/src/web/CareLeavers.Web/Views/Contentful/Page.cshtml
+++ b/src/web/CareLeavers.Web/Views/Contentful/Page.cshtml
@@ -54,7 +54,7 @@
             <partial name="LastUpdated" model="@Model"/>
         }
         
-        <partial name="ShareThis" model="Model.ShowShareThis"/>
+        <partial name="ShareThis" model="Model"/>
     </div>
     @if (Model.Width == PageWidth.TwoThirds)
     {

--- a/src/web/CareLeavers.Web/Views/Contentful/Page.cshtml
+++ b/src/web/CareLeavers.Web/Views/Contentful/Page.cshtml
@@ -48,11 +48,8 @@
             <gds-contentful-contents document="@Model.MainContent" levels="@Model.ContentsHeadings"/>
         }
         <gds-contentful-rich-text document="@Model.MainContent"></gds-contentful-rich-text>
-        @if (Model.ShowLastUpdated)
-        {
-            <hr/>
-            <partial name="LastUpdated" model="@Model"/>
-        }
+        
+        <partial name="LastUpdated" model="@Model"/>
         
         <partial name="ShareThis" model="Model"/>
     </div>

--- a/src/web/CareLeavers.Web/Views/Shared/LastUpdated.cshtml
+++ b/src/web/CareLeavers.Web/Views/Shared/LastUpdated.cshtml
@@ -1,30 +1,33 @@
 @using System.Globalization
 @model CareLeavers.Web.Models.Content.Page
 
-<div class="govuk-grid-row">
-    <div class="metadata-logo-wrapper">
-        <div class="govuk-grid-column-two-thirds metadata-column">
-            <div class="gem-c-metadata" data-module="gem-toggle metadata">
-                <dl class="gem-c-metadata__list">
-                    <dt class="gem-c-metadata__term">From:</dt>
-                    <dd class="gem-c-metadata__definition notranslate">
-                        <a class="govuk-link" href="https://www.gov.uk/government/organisations/department-for-education">Department for Education</a>
+@if (Model.ShowLastUpdated)
+{
+    <div class="govuk-grid-row">
+        <div class="metadata-logo-wrapper">
+            <div class="govuk-grid-column-two-thirds metadata-column">
+                <div class="gem-c-metadata" data-module="gem-toggle metadata">
+                    <dl class="gem-c-metadata__list">
+                        <dt class="gem-c-metadata__term">From:</dt>
+                        <dd class="gem-c-metadata__definition notranslate">
+                            <a class="govuk-link" href="https://www.gov.uk/government/organisations/department-for-education">Department for Education</a>
 
-                    </dd>
-                    <dt class="gem-c-metadata__term">Published</dt>
-                    <dd class="gem-c-metadata__definition">@Model.Sys.CreatedAt?.ToString("dd MMMM yyyy", DateTimeFormatInfo.InvariantInfo)</dd>
-                    <dt class="gem-c-metadata__term">Last updated</dt>
-                    <dd class="gem-c-metadata__definition">
-                        @Model.Sys.UpdatedAt?.ToString("dd MMMM yyyy", DateTimeFormatInfo.InvariantInfo)
-                    </dd>
-                </dl>
-            </div>
-            @if (Model.ShowShareThis && Model.ShowLastUpdated)
-            {
-                <div class="gem-c-print-link govuk-!-display-none-print govuk-!-margin-top-3 govuk-!-margin-bottom-8">
-                    <button class="govuk-link govuk-body-s gem-c-print-link__button" data-module="print-link" id="print-link">Print this page</button>
+                        </dd>
+                        <dt class="gem-c-metadata__term">Published</dt>
+                        <dd class="gem-c-metadata__definition">@Model.Sys.CreatedAt?.ToString("dd MMMM yyyy", DateTimeFormatInfo.InvariantInfo)</dd>
+                        <dt class="gem-c-metadata__term">Last updated</dt>
+                        <dd class="gem-c-metadata__definition">
+                            @Model.Sys.UpdatedAt?.ToString("dd MMMM yyyy", DateTimeFormatInfo.InvariantInfo)
+                        </dd>
+                    </dl>
                 </div>
-            }
+                @if (Model.ShowShareThis)
+                {
+                    <div class="gem-c-print-link govuk-!-display-none-print govuk-!-margin-top-3 govuk-!-margin-bottom-8">
+                        <button class="govuk-link govuk-body-s gem-c-print-link__button" data-module="print-link" id="print-link">Print this page</button>
+                    </div>
+                }
+            </div>
         </div>
     </div>
-</div>
+}

--- a/src/web/CareLeavers.Web/Views/Shared/LastUpdated.cshtml
+++ b/src/web/CareLeavers.Web/Views/Shared/LastUpdated.cshtml
@@ -19,7 +19,7 @@
                     </dd>
                 </dl>
             </div>
-            @if (Model.ShowShareThis)
+            @if (Model.ShowShareThis && Model.ShowLastUpdated)
             {
                 <div class="gem-c-print-link govuk-!-display-none-print govuk-!-margin-top-3 govuk-!-margin-bottom-8">
                     <button class="govuk-link govuk-body-s gem-c-print-link__button" data-module="print-link" id="print-link">Print this page</button>

--- a/src/web/CareLeavers.Web/Views/Shared/ShareThis.cshtml
+++ b/src/web/CareLeavers.Web/Views/Shared/ShareThis.cshtml
@@ -1,7 +1,24 @@
-@model bool
+@model CareLeavers.Web.Models.Content.Page
 
-@if (Model)
+@if (Model.ShowShareThis)
 {
+    @if (!Model.ShowLastUpdated)
+    {
+        <div class="govuk-grid-row">
+            <div class="metadata-logo-wrapper">
+                <div class="govuk-grid-column-two-thirds metadata-column">
+                    @if (Model.ShowShareThis && Model.ShowLastUpdated)
+                    {
+                        <div class="gem-c-print-link govuk-!-display-none-print govuk-!-margin-top-3 govuk-!-margin-bottom-8">
+                            <button class="govuk-link govuk-body-s gem-c-print-link__button" data-module="print-link" id="print-link">Print this page</button>
+                        </div>
+                    }
+                </div>
+            </div>
+        </div>
+
+    }
+    
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
             <h3 class="govuk-heading-m">Share this page</h3>

--- a/src/web/CareLeavers.Web/Views/Shared/ShareThis.cshtml
+++ b/src/web/CareLeavers.Web/Views/Shared/ShareThis.cshtml
@@ -2,21 +2,18 @@
 
 @if (Model.ShowShareThis)
 {
-    @if (!Model.ShowLastUpdated)
+    if (!Model.ShowLastUpdated)
     {
+        <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible"/>
         <div class="govuk-grid-row">
             <div class="metadata-logo-wrapper">
                 <div class="govuk-grid-column-two-thirds metadata-column">
-                    @if (Model.ShowShareThis && Model.ShowLastUpdated)
-                    {
                         <div class="gem-c-print-link govuk-!-display-none-print govuk-!-margin-top-3 govuk-!-margin-bottom-8">
                             <button class="govuk-link govuk-body-s gem-c-print-link__button" data-module="print-link" id="print-link">Print this page</button>
                         </div>
-                    }
                 </div>
             </div>
         </div>
-
     }
     
     <div class="govuk-grid-row">

--- a/src/web/tests/CareLeavers.Integration.Tests/Tests/SnapshotTests/Output/ComponentTest.html
+++ b/src/web/tests/CareLeavers.Integration.Tests/Tests/SnapshotTests/Output/ComponentTest.html
@@ -174,7 +174,6 @@
 								</div>
 							</section>
 							<p class="govuk-body"></p>
-							<hr>
 							<div class="govuk-grid-row">
 								<div class="metadata-logo-wrapper">
 									<div class="govuk-grid-column-two-thirds metadata-column">

--- a/src/web/tests/CareLeavers.Integration.Tests/Tests/SnapshotTests/Output/HomePageWithSupport.html
+++ b/src/web/tests/CareLeavers.Integration.Tests/Tests/SnapshotTests/Output/HomePageWithSupport.html
@@ -181,7 +181,6 @@
 							</div>
 						</section>
 						<p class="govuk-body"></p>
-						<hr>
 						<div class="govuk-grid-row">
 							<div class="metadata-logo-wrapper">
 								<div class="govuk-grid-column-two-thirds metadata-column">

--- a/src/web/tests/CareLeavers.Integration.Tests/Tests/SnapshotTests/Output/SimpleAsset.html
+++ b/src/web/tests/CareLeavers.Integration.Tests/Tests/SnapshotTests/Output/SimpleAsset.html
@@ -133,6 +133,26 @@
 					<div class="govuk-grid-column-two-thirds">
 						<img class="full-width-image" src="//images.ctfassets.net/3y72rykjd1o5/71UfwHVCjz9O7RxA0e3jrJ/10a9c71dd9d5aa3ef795b1a571aa33d4/Test.png" alt="Test alt description">
 						<p class="govuk-body"></p>
+						<div class="govuk-grid-row">
+							<div class="metadata-logo-wrapper">
+								<div class="govuk-grid-column-two-thirds metadata-column">
+									<div class="gem-c-metadata" data-module="gem-toggle metadata">
+										<dl class="gem-c-metadata__list">
+											<dt class="gem-c-metadata__term">From:</dt>
+											<dd class="gem-c-metadata__definition notranslate">
+												<a class="govuk-link" href="https://www.gov.uk/government/organisations/department-for-education">Department for Education</a>
+											</dd>
+											<dt class="gem-c-metadata__term">Published</dt>
+											<dd class="gem-c-metadata__definition">30 January 2025</dd>
+											<dt class="gem-c-metadata__term">Last updated</dt>
+											<dd class="gem-c-metadata__definition">
+												30 January 2025
+											</dd>
+										</dl>
+									</div>
+								</div>
+							</div>
+						</div>
 					</div>
 					<div class="govuk-grid-column-one-third">
 					</div>

--- a/src/web/tests/CareLeavers.Integration.Tests/Tests/SnapshotTests/Output/SimpleParagraph.html
+++ b/src/web/tests/CareLeavers.Integration.Tests/Tests/SnapshotTests/Output/SimpleParagraph.html
@@ -130,6 +130,25 @@
 						<p class="govuk-body">Test 2</p>
 						<p class="govuk-body"></p>
 						<p class="govuk-body"></p>
+						<div class="govuk-grid-row">
+							<div class="metadata-logo-wrapper">
+								<div class="govuk-grid-column-two-thirds metadata-column">
+									<div class="gem-c-metadata" data-module="gem-toggle metadata">
+										<dl class="gem-c-metadata__list">
+											<dt class="gem-c-metadata__term">From:</dt>
+											<dd class="gem-c-metadata__definition notranslate">
+												<a class="govuk-link" href="https://www.gov.uk/government/organisations/department-for-education">Department for Education</a>
+											</dd>
+											<dt class="gem-c-metadata__term">Published</dt>
+											<dd class="gem-c-metadata__definition"></dd>
+											<dt class="gem-c-metadata__term">Last updated</dt>
+											<dd class="gem-c-metadata__definition">
+											</dd>
+										</dl>
+									</div>
+								</div>
+							</div>
+						</div>
 					</div>
 					<div class="govuk-grid-column-one-third">
 					</div>


### PR DESCRIPTION
So it turns out that the logic to always show a print button is fun, because the print button is part of the metadata styling...

The logic now is:
- If Share is turned on, but Last Updated is off, add a new metadata section with JUST the print button
- If Share is on and Last Updated is on, show the print button as part of the last updated block
- If Share is off and Last Updated is on, don't show the share links or the print button

Simples... right?

Anyway, this PR does that ⬆️ 😄 