### PR TITLE
Add definition links

### DIFF
--- a/src/contentful/CareLeavers.ContentfulMigration/Migrations/0029-allow-definition-blocks-in-rich-content.cjs
+++ b/src/contentful/CareLeavers.ContentfulMigration/Migrations/0029-allow-definition-blocks-in-rich-content.cjs
@@ -1,0 +1,62 @@
+module.exports = function (migration) {
+    const richContent = migration
+        .editContentType("richContent");
+
+    richContent
+        .editField("content")
+        .validations([
+            {
+                enabledMarks: [
+                    "bold",
+                    "italic"
+                ]
+            },
+            {
+                enabledNodeTypes: [
+                    "heading-2",
+                    "heading-3",
+                    "heading-4",
+                    "ordered-list",
+                    "unordered-list",
+                    "embedded-entry-block",
+                    "embedded-asset-block",
+                    "entry-hyperlink",
+                    "hyperlink",
+                    "embedded-entry-inline",
+                    "hr"
+                ],
+                message: "Only heading 2, heading 3, heading 4, ordered list, unordered list, block entry, asset, link to entry, link to Url, inline entry, and horizontal rule nodes are allowed"
+            },
+            {
+                nodes: {
+                    "embedded-entry-block": [
+                        {
+                            "linkContentType": [
+                                "callToAction",
+                                "grid",
+                                "banner",
+                                "definitionBlock"
+                            ],
+                            "message": null
+                        }
+                    ],
+                    "embedded-entry-inline": [
+                        {
+                            "linkContentType": [
+                                "definitionLink"
+                            ],
+                            "message": null
+                        }
+                    ],
+                    "entry-hyperlink": [
+                        {
+                            "linkContentType": [
+                                "page"
+                            ],
+                            "message": null
+                        }
+                    ]
+                }
+            }
+        ])
+};

--- a/src/contentful/CareLeavers.ContentfulMigration/Migrations/0030-allow-headings-in-definition-content.cjs
+++ b/src/contentful/CareLeavers.ContentfulMigration/Migrations/0030-allow-headings-in-definition-content.cjs
@@ -1,0 +1,27 @@
+module.exports = function (migration) {
+    const definitionContent = migration
+        .editContentType("definitionContent");
+
+    definitionContent
+        .editField("definition")
+        .validations([
+            {
+                enabledMarks: [
+                    "bold",
+                    "italic"
+                ]
+            },
+            {
+                enabledNodeTypes: [
+                    "heading-2",
+                    "heading-3",
+                    "heading-4",
+                    "ordered-list",
+                    "unordered-list",
+                    "entry-hyperlink",
+                    "hyperlink",
+                    "embedded-entry-inline"
+                ]
+            }
+        ]);
+};

--- a/src/contentful/CareLeavers.ContentfulMigration/Migrations/0031-rename-definition-fields.cjs
+++ b/src/contentful/CareLeavers.ContentfulMigration/Migrations/0031-rename-definition-fields.cjs
@@ -1,0 +1,35 @@
+module.exports = function (migration) {
+    const definitionBlock = migration
+        .editContentType("definitionBlock");
+
+    const definitionLink = migration
+        .editContentType("definitionLink");
+    
+    const definitionContent = migration
+        .editContentType("definitionContent");
+
+    // Rename the field IDs
+    definitionBlock
+        .changeFieldId('definition', 'definitionContent')
+
+    definitionLink
+        .changeFieldId('definition', 'definitionBlock')
+
+    definitionContent
+        .changeFieldId('definition', 'content')
+    
+    // Now rename the fields
+    definitionBlock
+        .editField('definitionContent')
+        .name('Definition Content')
+
+    definitionLink
+        .editField('definitionBlock')
+        .name('Definition Block')
+
+    definitionContent
+        .editField('content')
+        .name('Content')
+
+
+};

--- a/src/contentful/CareLeavers.ContentfulMigration/Migrations/0032-move-page-from-definition-content-to-link.cjs
+++ b/src/contentful/CareLeavers.ContentfulMigration/Migrations/0032-move-page-from-definition-content-to-link.cjs
@@ -1,0 +1,27 @@
+module.exports = function (migration) {
+    const definitionLink = migration
+        .editContentType("definitionLink");
+    
+    const definitionContent = migration
+        .editContentType("definitionContent");
+    
+    definitionLink
+        .createField("page")
+        .name("Page")
+        .type("Link")
+        .localized(false)
+        .required(false)
+        .validations([
+            {
+                linkContentType: ["page"],
+            },
+        ])
+        .linkType("Entry")
+        .disabled(false)
+        .omitted(false);
+
+    definitionContent
+        .deleteField('page')
+
+
+};

--- a/src/web/CareLeavers.Web/Contentful/ContentfulContentService.cs
+++ b/src/web/CareLeavers.Web/Contentful/ContentfulContentService.cs
@@ -28,7 +28,7 @@ public class ContentfulContentService : IContentService
             var pages = new QueryBuilder<Page>()
                 .ContentTypeIs(Page.ContentType)
                 .FieldEquals(c => c.Slug, slug)
-                .Include(5)
+                .Include(4)
                 .Limit(1);
 
             var pageEntries = await _contentfulClient.GetEntries(pages);
@@ -43,7 +43,7 @@ public class ContentfulContentService : IContentService
         {
             var query = new QueryBuilder<StatusChecker>()
                 .ContentTypeIs(StatusChecker.ContentType)
-                .Include(5)
+                .Include(4)
                 .Limit(1);
             
             return await _contentfulClient.GetEntry(id, query);
@@ -56,7 +56,7 @@ public class ContentfulContentService : IContentService
         {
             var config = new QueryBuilder<ContentfulConfigurationEntity>()
                 .ContentTypeIs(ContentfulConfigurationEntity.ContentType)
-                .Include(5)
+                .Include(2)
                 .Limit(1);
 
             var configEntries = await _contentfulClient.GetEntries(config);

--- a/src/web/CareLeavers.Web/Contentful/ContentfulEntityResolver.cs
+++ b/src/web/CareLeavers.Web/Contentful/ContentfulEntityResolver.cs
@@ -17,6 +17,8 @@ public class ContentfulEntityResolver : IContentTypeResolver
         { Riddle.ContentType, typeof(Riddle) },
         { StatusChecker.ContentType, typeof(StatusChecker) },
         { Banner.ContentType, typeof(Banner) },
+        { DefinitionLink.ContentType, typeof(DefinitionLink) },
+        { DefinitionBlock.ContentType, typeof(DefinitionBlock) },
     };
     
     public Type? Resolve(string contentTypeId)

--- a/src/web/CareLeavers.Web/ContentfulRenderers/GDSDefinitionBlockRenderer.cs
+++ b/src/web/CareLeavers.Web/ContentfulRenderers/GDSDefinitionBlockRenderer.cs
@@ -1,0 +1,35 @@
+using CareLeavers.Web.Models.Content;
+using Contentful.Core.Models;
+
+namespace CareLeavers.Web.ContentfulRenderers;
+
+public class GDSDefinitionBlockRenderer(IServiceProvider serviceProvider) : GDSRazorContentRenderer(serviceProvider)
+{
+    public override bool SupportsContent(IContent content)
+    {
+        if (content is EntryStructure { NodeType: "embedded-entry-block" } entryStructure)
+        {
+            if (entryStructure.Data.Target is DefinitionBlock)
+            {
+                return true;
+            }
+        }
+
+        return content is DefinitionBlock;
+    }
+
+    public override Task<string> RenderAsync(IContent content)
+    {
+        DefinitionBlock? definitionBlock;
+        if (content is DefinitionBlock)
+        {
+            definitionBlock = content as DefinitionBlock;
+        }
+        else
+        {
+            definitionBlock = (content as EntryStructure)?.Data.Target as DefinitionBlock;
+        }
+
+        return RenderToString("Shared/DefinitionBlock", definitionBlock);
+    }
+}

--- a/src/web/CareLeavers.Web/ContentfulRenderers/GDSDefinitionLinkRenderer.cs
+++ b/src/web/CareLeavers.Web/ContentfulRenderers/GDSDefinitionLinkRenderer.cs
@@ -1,0 +1,62 @@
+using CareLeavers.Web.Models.Content;
+using Contentful.Core.Models;
+using GovUk.Frontend.AspNetCore;
+using Microsoft.AspNetCore.Mvc.Rendering;
+
+namespace CareLeavers.Web.ContentfulRenderers;
+
+public class GDSDefinitionLinkRenderer() : IContentRenderer
+{
+    public bool SupportsContent(IContent content)
+    {
+        if (content is EntryStructure { NodeType: "embedded-entry-inline" } entryStructure)
+        {
+            if (entryStructure.Data.Target is DefinitionLink)
+            {
+                return true;
+            }
+        }
+
+        return content is DefinitionLink;
+
+    }
+
+    public async Task<string> RenderAsync(IContent content)
+    {
+        var tb = new TagBuilder("a");
+        tb.AddCssClass("govuk-link");
+        DefinitionLink? link = null;
+        if (content is EntryStructure { NodeType: "embedded-entry-inline" } entryStructure)
+        {
+            if (entryStructure.Data.Target is DefinitionLink)
+            {
+                link = entryStructure.Data.Target as DefinitionLink;
+            }
+        }
+        else
+        {
+            link = content as DefinitionLink;
+        }
+
+        if (link != null)
+        {
+
+            // Get page slug
+            var slug = link.Page.Slug;
+
+            // Get sanitised id for anchor
+            var anchor = TagBuilder.CreateSanitizedId(link.DefinitionBlock.Title, "-");
+            
+            // Set link
+            tb.Attributes["href"] = $"/{slug}#{anchor}";
+
+            // Use the title from the link
+            tb.InnerHtml.Append(link.Title);
+            
+        }
+
+        return tb.HasInnerHtml ? tb.ToHtmlString() : string.Empty;
+    }
+
+    public int Order { get; set; } = 10;
+}

--- a/src/web/CareLeavers.Web/ContentfulRenderers/GDSLinkRenderer.cs
+++ b/src/web/CareLeavers.Web/ContentfulRenderers/GDSLinkRenderer.cs
@@ -5,7 +5,7 @@ using Microsoft.AspNetCore.Mvc.Rendering;
 
 namespace CareLeavers.Web.ContentfulRenderers;
 
-public class GDSEntityLinkContentRenderer(ContentRendererCollection rendererCollection) : IContentRenderer
+public class GDSLinkRenderer(ContentRendererCollection rendererCollection) : IContentRenderer
 {
     public bool SupportsContent(IContent content)
     {

--- a/src/web/CareLeavers.Web/Models/Content/DefinitionBlock.cs
+++ b/src/web/CareLeavers.Web/Models/Content/DefinitionBlock.cs
@@ -1,0 +1,13 @@
+namespace CareLeavers.Web.Models.Content;
+
+public class DefinitionBlock : ContentfulContent
+{
+    public static string ContentType { get; } = "definitionBlock";
+    
+    public required string Title { get; set; }
+
+    public bool ShowTitle { get; set; } = false;
+    
+    public required DefinitionContent DefinitionContent { get; set; }
+    
+}

--- a/src/web/CareLeavers.Web/Models/Content/DefinitionContent.cs
+++ b/src/web/CareLeavers.Web/Models/Content/DefinitionContent.cs
@@ -1,0 +1,13 @@
+using Contentful.Core.Models;
+
+namespace CareLeavers.Web.Models.Content;
+
+public class DefinitionContent : ContentfulContent
+{
+    public static string ContentType { get; } = "definitionContent";
+    
+    public required string Title { get; set; }
+    
+    public required Document Content { get; set; }
+    
+}

--- a/src/web/CareLeavers.Web/Models/Content/DefinitionLink.cs
+++ b/src/web/CareLeavers.Web/Models/Content/DefinitionLink.cs
@@ -1,0 +1,13 @@
+namespace CareLeavers.Web.Models.Content;
+
+public class DefinitionLink : ContentfulContent
+{
+    public static string ContentType { get; } = "definitionLink";
+    
+    public required string Title { get; set; }
+    
+    public required DefinitionBlock DefinitionBlock { get; set; }
+    
+    public required Page Page { get; set; }
+    
+}

--- a/src/web/CareLeavers.Web/Program.cs
+++ b/src/web/CareLeavers.Web/Program.cs
@@ -139,10 +139,12 @@ try
         renderer.AddRenderer(new GDSGridRenderer(serviceProvider));
         renderer.AddRenderer(new GDSHorizontalRulerContentRenderer());
         renderer.AddRenderer(new GDSRichContentRenderer(serviceProvider));
-        renderer.AddRenderer(new GDSEntityLinkContentRenderer(renderer.Renderers));
+        renderer.AddRenderer(new GDSLinkRenderer(renderer.Renderers));
         renderer.AddRenderer(new GDSStatusCheckerRenderer(serviceProvider));
         renderer.AddRenderer(new GDSRiddleRenderer(serviceProvider));
         renderer.AddRenderer(new GDSBannerRenderer(serviceProvider));
+        renderer.AddRenderer(new GDSDefinitionBlockRenderer(serviceProvider));
+        renderer.AddRenderer(new GDSDefinitionLinkRenderer());
 
         return renderer;
     });
@@ -201,6 +203,8 @@ try
     {
         NamingStrategy = new CamelCaseNamingStrategy()
     };
+    contentfulClient.SerializerSettings.MaxDepth = 128;
+    contentfulClient.Serializer.MaxDepth = 128;
 
     Constants.Serializer = contentfulClient.Serializer;
     Constants.SerializerSettings = contentfulClient.SerializerSettings;

--- a/src/web/CareLeavers.Web/Views/Shared/DefinitionBlock.cshtml
+++ b/src/web/CareLeavers.Web/Views/Shared/DefinitionBlock.cshtml
@@ -1,0 +1,11 @@
+@model CareLeavers.Web.Models.Content.DefinitionBlock
+
+<div id="@TagBuilder.CreateSanitizedId(Model.Title, "-")" title="@Model.Title" role="definition">
+    @if (Model.ShowTitle)
+    {
+        <h3 class="govuk-heading-m">
+            @Model.Title
+        </h3>
+    }
+    <gds-contentful-rich-text document="@Model.DefinitionContent.Content"></gds-contentful-rich-text>
+</div>


### PR DESCRIPTION
Added the following:
- Definition Link
- Definition Content
- Definition Block

Updated the following:
- Renamed linked entity renderer to a link renderer, as it handles all links now
- Reduced recursion depth to 4 from 5 to avoid circular references and massive JSON payloads