### PR TITLE
Accessibility Improvements

### DIFF
--- a/src/e2e/CareLeavers.E2ETests/src/pages/BasePage.ts
+++ b/src/e2e/CareLeavers.E2ETests/src/pages/BasePage.ts
@@ -44,7 +44,7 @@ export class BasePage {
     constructor(page: Page) {
         this.page = page;
         //Locator for the Website Title navigation Link
-        this.WebsiteNameLink = page.locator('a.dfe-header__link--service').nth(1);
+        this.WebsiteNameLink = page.locator('a.dfe-header__link--service');
 
         // Locators for cookie banner and buttons
         this.cookieBanner = page.locator('.govuk-cookie-banner');

--- a/src/e2e/CareLeavers.E2ETests/src/pages/BasePage.ts
+++ b/src/e2e/CareLeavers.E2ETests/src/pages/BasePage.ts
@@ -66,7 +66,7 @@ export class BasePage {
         this.closeMenuButton = page.locator('#close-menu');
 
         // Locators for social media share buttons
-        this.shareButtonsContainer = page.locator('.sharethis-inline-share-buttons');
+        this.shareButtonsContainer = page.locator('.shareaholic-canvas');
         this.printShareButton = page.locator('#print-link');
 
         // Locators for Metadata definitions

--- a/src/e2e/CareLeavers.E2ETests/src/tests/SharedLinks.spec.ts
+++ b/src/e2e/CareLeavers.E2ETests/src/tests/SharedLinks.spec.ts
@@ -17,7 +17,7 @@ test.describe('Shared Website Functionalities', () => {
             test(`Validate navigation links on ${path}`, async () => {
                 // Navigate to page & check that WebsiteNameLink is visible
                 await basePage.navigateTo(path);
-                await expect(basePage.WebsiteNameLink).toHaveText(/Support for/i);
+                await expect(basePage.WebsiteNameLink).toHaveAccessibleName(/Support for/i);
                 await expect(basePage.WebsiteNameLink).toBeVisible();
             });
         });

--- a/src/web/CareLeavers.Web/AssetSrc/scss/application.scss
+++ b/src/web/CareLeavers.Web/AssetSrc/scss/application.scss
@@ -42,6 +42,9 @@ $govuk-font-family: 'Inter', sans-serif; // Override govuk font
 .hf-card a {
   text-decoration: none;
 }
+.hf-card:focus-within {
+  @include govuk-focused-text;
+}
 
 .hf-card a .hf-card-details p {
   color: #0b0c0c;
@@ -52,10 +55,17 @@ $govuk-font-family: 'Inter', sans-serif; // Override govuk font
   color: #155388;
 }
 
+.hf-card:focus-within a .hf-card-container,
 .hf-card a:hover .hf-card-container {
   background-color: #003a69;
 }
 
+.hf-card:focus-within a .hf-card-container .hf-card-details p,
+.hf-card:focus-within a .hf-card-container .hf-card-details h2,
+.hf-card:focus-within a .hf-card-container .hf-card-details h3,
+.hf-card:focus-within a .hf-card-container .cat-card-details p,
+.hf-card:focus-within a .hf-card-container .cat-card-details h2,
+.hf-card:focus-within a .hf-card-container .cat-card-details h3,
 .hf-card a:hover .hf-card-container .hf-card-details p,
 .hf-card a:hover .hf-card-container .hf-card-details h2,
 .hf-card a:hover .hf-card-container .hf-card-details h3,
@@ -385,11 +395,10 @@ html
 
 .dfe-header .dfe-header__service-name {
   text-align: right;
-}
-
-a.dfe-header__link--service {
+  @include dfe-font(22);
   font-weight: 800;
 }
+
 
 .riddle2-wrapper {
   max-width:100%; width:100%;

--- a/src/web/CareLeavers.Web/Configuration/ScriptOptions.cs
+++ b/src/web/CareLeavers.Web/Configuration/ScriptOptions.cs
@@ -11,7 +11,9 @@ public class ScriptOptions
 
     public string? Clarity { get; init; } = "";
     
-    public string? ShareThis { get; init; } = "";
+    public string? ShareaholicSiteId { get; init; } = "";
+    
+    public string? ShareaholicAppId { get; init; } = "";
     
     public bool ShowCookieBanner { get; init; }
 

--- a/src/web/CareLeavers.Web/Contentful/ContentfulContentService.cs
+++ b/src/web/CareLeavers.Web/Contentful/ContentfulContentService.cs
@@ -2,7 +2,6 @@ using CareLeavers.Web.Caching;
 using CareLeavers.Web.Models.Content;
 using CareLeavers.Web.Models.ViewModels;
 using Contentful.Core;
-using Contentful.Core.Models;
 using Contentful.Core.Search;
 using Microsoft.Extensions.Caching.Distributed;
 

--- a/src/web/CareLeavers.Web/Contentful/IContentService.cs
+++ b/src/web/CareLeavers.Web/Contentful/IContentService.cs
@@ -1,6 +1,5 @@
 using CareLeavers.Web.Models.Content;
 using CareLeavers.Web.Models.ViewModels;
-using Contentful.Core.Models;
 
 namespace CareLeavers.Web.Contentful;
 

--- a/src/web/CareLeavers.Web/ContentfulRenderers/GDSListRenderer.cs
+++ b/src/web/CareLeavers.Web/ContentfulRenderers/GDSListRenderer.cs
@@ -1,0 +1,60 @@
+using Contentful.Core.Models;
+using GovUk.Frontend.AspNetCore;
+using Microsoft.AspNetCore.Mvc.Rendering;
+
+namespace CareLeavers.Web.ContentfulRenderers;
+
+/// <summary>
+/// A renderer for a list.
+/// </summary>
+public class GDSListRenderer(ContentRendererCollection rendererCollection) : IContentRenderer
+{
+
+    /// <summary>
+    /// Whether or not this renderer supports the provided content.
+    /// </summary>
+    /// <param name="content">The content to evaluate.</param>
+    /// <returns>Returns true if the content is a list, otherwise false.</returns>
+    public bool SupportsContent(IContent content)
+    {
+        return content is List;
+    }
+    
+    /// <summary>
+    /// Renders the content asynchronously.
+    /// </summary>
+    /// <param name="content">The content to render.</param>
+    /// <returns>The list as a ul or ol HTML string.</returns>
+    public async Task<string> RenderAsync(IContent content)
+    {
+        var list = content as List;
+        if (list == null)
+        {
+            return string.Empty;
+        }
+        
+        var listTagType = "ul";
+        var listClass = "govuk-list govuk-list--bullet";
+        if (list.NodeType == "ordered-list")
+        {
+            listTagType = "ol";
+            listClass = "govuk-list govuk-list--number";
+        }
+
+        var tb = new TagBuilder(listTagType);
+        tb.AddCssClass(listClass);
+            
+
+        foreach (var subContent in list.Content)
+        {
+            var renderer = rendererCollection.GetRendererForContent(subContent);
+            tb.InnerHtml.AppendHtml(await renderer.RenderAsync(subContent));
+        }
+
+
+        return tb.ToHtmlString();
+    }
+    
+    public int Order { get; set; } = 10;
+
+}

--- a/src/web/CareLeavers.Web/ContentfulRenderers/GDSRichContentRenderer.cs
+++ b/src/web/CareLeavers.Web/ContentfulRenderers/GDSRichContentRenderer.cs
@@ -1,4 +1,3 @@
-using CareLeavers.Web.Contentful;
 using CareLeavers.Web.Models.Content;
 using Contentful.Core.Models;
 

--- a/src/web/CareLeavers.Web/ContentfulRenderers/GDSRiddleRenderer.cs
+++ b/src/web/CareLeavers.Web/ContentfulRenderers/GDSRiddleRenderer.cs
@@ -1,8 +1,5 @@
 using CareLeavers.Web.Models.Content;
-using Contentful.AspNetCore.Authoring;
 using Contentful.Core.Models;
-using Microsoft.AspNetCore.Mvc.Razor;
-using Microsoft.AspNetCore.Mvc.ViewFeatures;
 
 namespace CareLeavers.Web.ContentfulRenderers;
 

--- a/src/web/CareLeavers.Web/ContentfulRenderers/GDSStatusCheckerRenderer.cs
+++ b/src/web/CareLeavers.Web/ContentfulRenderers/GDSStatusCheckerRenderer.cs
@@ -1,8 +1,5 @@
 using CareLeavers.Web.Models.Content;
-using Contentful.AspNetCore.Authoring;
 using Contentful.Core.Models;
-using Microsoft.AspNetCore.Mvc.Razor;
-using Microsoft.AspNetCore.Mvc.ViewFeatures;
 
 namespace CareLeavers.Web.ContentfulRenderers;
 

--- a/src/web/CareLeavers.Web/Controllers/ContentfulController.cs
+++ b/src/web/CareLeavers.Web/Controllers/ContentfulController.cs
@@ -1,15 +1,10 @@
 using System.Diagnostics.CodeAnalysis;
-using System.Text;
-using System.Xml.Linq;
 using CareLeavers.Web.Configuration;
 using CareLeavers.Web.Contentful;
 using CareLeavers.Web.Models.Content;
-using Contentful.Core.Configuration;
 using Contentful.Core.Models;
 using Microsoft.AspNetCore.Mvc;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Serialization;
-using Formatting = Newtonsoft.Json.Formatting;
 
 namespace CareLeavers.Web.Controllers;
 

--- a/src/web/CareLeavers.Web/Controllers/SitemapController.cs
+++ b/src/web/CareLeavers.Web/Controllers/SitemapController.cs
@@ -1,13 +1,7 @@
-using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using System.Xml.Linq;
-using CareLeavers.Web.Configuration;
 using CareLeavers.Web.Contentful;
-using Contentful.Core.Configuration;
 using Microsoft.AspNetCore.Mvc;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Serialization;
-using Formatting = Newtonsoft.Json.Formatting;
 
 namespace CareLeavers.Web.Controllers;
 

--- a/src/web/CareLeavers.Web/Controllers/StatusCheckerController.cs
+++ b/src/web/CareLeavers.Web/Controllers/StatusCheckerController.cs
@@ -1,5 +1,4 @@
 using CareLeavers.Web.Contentful;
-using CareLeavers.Web.Models.Content;
 using Microsoft.AspNetCore.Mvc;
 
 namespace CareLeavers.Web.Controllers;

--- a/src/web/CareLeavers.Web/Models/ViewModels/SimplePage.cs
+++ b/src/web/CareLeavers.Web/Models/ViewModels/SimplePage.cs
@@ -1,6 +1,3 @@
-using System.Text.Json.Serialization;
-using CareLeavers.Web.Models.Content;
-
 namespace CareLeavers.Web.Models.ViewModels;
 
 public class SimplePage

--- a/src/web/CareLeavers.Web/Program.cs
+++ b/src/web/CareLeavers.Web/Program.cs
@@ -116,15 +116,16 @@ try
         renderer.AddRenderer(new GDSParagraphRenderer(renderer.Renderers));
         renderer.AddRenderer(new GDSHeaderRenderer(renderer.Renderers));
         renderer.AddRenderer(new GDSAssetRenderer(renderer.Renderers));
-        renderer.AddRenderer(new GDSGridRenderer(serviceProvider));
-        renderer.AddRenderer(new GDSHorizontalRulerContentRenderer());
-        renderer.AddRenderer(new GDSRichContentRenderer(serviceProvider));
         renderer.AddRenderer(new GDSLinkRenderer(renderer.Renderers));
+        renderer.AddRenderer(new GDSListRenderer(renderer.Renderers));
+        renderer.AddRenderer(new GDSHorizontalRulerContentRenderer());
+        renderer.AddRenderer(new GDSDefinitionLinkRenderer());
+        renderer.AddRenderer(new GDSGridRenderer(serviceProvider));
+        renderer.AddRenderer(new GDSRichContentRenderer(serviceProvider));
         renderer.AddRenderer(new GDSStatusCheckerRenderer(serviceProvider));
         renderer.AddRenderer(new GDSRiddleRenderer(serviceProvider));
         renderer.AddRenderer(new GDSBannerRenderer(serviceProvider));
         renderer.AddRenderer(new GDSDefinitionRenderer(serviceProvider));
-        renderer.AddRenderer(new GDSDefinitionLinkRenderer());
 
         return renderer;
     });

--- a/src/web/CareLeavers.Web/Views/Contentful/Page.cshtml
+++ b/src/web/CareLeavers.Web/Views/Contentful/Page.cshtml
@@ -51,7 +51,7 @@
         
         <partial name="LastUpdated" model="@Model"/>
         
-        <partial name="ShareThis" model="Model"/>
+        <partial name="Shareaholic" model="Model"/>
     </div>
     @if (Model.Width == PageWidth.TwoThirds)
     {

--- a/src/web/CareLeavers.Web/Views/Shared/Breadcrumbs.cshtml
+++ b/src/web/CareLeavers.Web/Views/Shared/Breadcrumbs.cshtml
@@ -1,4 +1,3 @@
-@using CareLeavers.Web.Configuration
 @using CareLeavers.Web.Contentful
 @model CareLeavers.Web.Models.Content.Page
 @inject IContentService ContentService

--- a/src/web/CareLeavers.Web/Views/Shared/Grid/AlternatingImageAndText.cshtml
+++ b/src/web/CareLeavers.Web/Views/Shared/Grid/AlternatingImageAndText.cshtml
@@ -6,9 +6,7 @@
     <div class="govuk-!-margin-top-3 govuk-!-margin-bottom-5">
         <div class="govuk-grid-row split-panel" style="background: #f3f2f1; vertical-align: text-top;">
             <div class="govuk-grid-column-one-half image-column">
-                <a href="@link" class="govuk-link">
-                    <div class="image-container" style="background-image: url('@Model?.Image?.File?.Url');"></div>
-                </a>
+                <div class="image-container" style="background-image: url('@Model?.Image?.File?.Url');"></div>
             </div>
             <div class="govuk-grid-column-one-half text-column">
                 @if (Model!.Types!.Any())

--- a/src/web/CareLeavers.Web/Views/Shared/Grid/ExternalAgency.cshtml
+++ b/src/web/CareLeavers.Web/Views/Shared/Grid/ExternalAgency.cshtml
@@ -10,7 +10,7 @@
     <div class="box-content">
         <h3 class="govuk-heading-s"><a href="@Model.Url" target="_blank" class="govuk-link">@Model.Name</a> <span class="govuk-body-s">(Opens in a new tab)</span></h3>
         <p class="govuk-body-s">@Model.Description</p>
-        <p class="govuk-body-s"><strong>Call:</strong> <a href="tel://@Model.Call">@Model.Call</a></p>
+        <p class="govuk-body-s"><strong>Call:</strong> <a href="tel:@Model.Call">@Model.Call</a></p>
         <p class="govuk-body-s"><strong>Opening times:</strong> @Model.OpeningTimes</p>
         <p class="govuk-body-s"><strong>Free:</strong> @(Model.Free ? "Yes" : "No")</p>
         <p class="govuk-body-s"><strong>Accessibility:</strong> @Model.Accessibility</p>

--- a/src/web/CareLeavers.Web/Views/Shared/Grid/ExternalAgency.cshtml
+++ b/src/web/CareLeavers.Web/Views/Shared/Grid/ExternalAgency.cshtml
@@ -10,7 +10,7 @@
     <div class="box-content">
         <h3 class="govuk-heading-s"><a href="@Model.Url" target="_blank" class="govuk-link">@Model.Name</a> <span class="govuk-body-s">(Opens in a new tab)</span></h3>
         <p class="govuk-body-s">@Model.Description</p>
-        <p class="govuk-body-s"><strong>Call:</strong> @Model.Call</p>
+        <p class="govuk-body-s"><strong>Call:</strong> <a href="tel://@Model.Call">@Model.Call</a></p>
         <p class="govuk-body-s"><strong>Opening times:</strong> @Model.OpeningTimes</p>
         <p class="govuk-body-s"><strong>Free:</strong> @(Model.Free ? "Yes" : "No")</p>
         <p class="govuk-body-s"><strong>Accessibility:</strong> @Model.Accessibility</p>

--- a/src/web/CareLeavers.Web/Views/Shared/Shareaholic.cshtml
+++ b/src/web/CareLeavers.Web/Views/Shared/Shareaholic.cshtml
@@ -1,16 +1,21 @@
+@using CareLeavers.Web.Configuration
+@using Microsoft.Extensions.Options
 @model CareLeavers.Web.Models.Content.Page
+@inject IOptions<ScriptOptions> ScriptOptions
 
 @if (Model.ShowShareThis)
 {
+    var scriptConfig = ScriptOptions.Value;
+
     if (!Model.ShowLastUpdated)
     {
         <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible"/>
         <div class="govuk-grid-row">
             <div class="metadata-logo-wrapper">
                 <div class="govuk-grid-column-two-thirds metadata-column">
-                        <div class="gem-c-print-link govuk-!-display-none-print govuk-!-margin-top-3 govuk-!-margin-bottom-8">
-                            <button class="govuk-link govuk-body-s gem-c-print-link__button" data-module="print-link" id="print-link">Print this page</button>
-                        </div>
+                    <div class="gem-c-print-link govuk-!-display-none-print govuk-!-margin-top-3 govuk-!-margin-bottom-8">
+                        <button class="govuk-link govuk-body-s gem-c-print-link__button" data-module="print-link" id="print-link">Print this page</button>
+                    </div>
                 </div>
             </div>
         </div>
@@ -19,7 +24,7 @@
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
             <h3 class="govuk-heading-m">Share this page</h3>
-            <div class="sharethis-inline-share-buttons"></div>
+            <div class="shareaholic-canvas" data-app="share_buttons" data-app-id="@scriptConfig.ShareaholicAppId"></div>
         </div>
     </div>
 }

--- a/src/web/CareLeavers.Web/Views/Shared/_Header.cshtml
+++ b/src/web/CareLeavers.Web/Views/Shared/_Header.cshtml
@@ -43,9 +43,9 @@
             </button>
         </div>
         <div class="dfe-header__logo">
-            <a class="dfe-header__link dfe-header__link--service " href="~/" aria-label="DfE homepage">
-                <img src="~/assets/dfe-logo.png" class="dfe-logo" alt="DfE Homepage">
-                <img src="~/assets/dfe-logo-alt.png" class="dfe-logo-hover" alt="DfE Homepage">
+            <a class="dfe-header__link dfe-header__link--service " href="~/" aria-label="@Model.ServiceName homepage">
+                <img src="~/assets/dfe-logo.png" class="dfe-logo" alt="@Model.ServiceName homepage">
+                <img src="~/assets/dfe-logo-alt.png" class="dfe-logo-hover" alt="@Model.ServiceName homepage">
             </a>
         </div>
         <div class="dfe-header__content" id="content-header">

--- a/src/web/CareLeavers.Web/Views/Shared/_Header.cshtml
+++ b/src/web/CareLeavers.Web/Views/Shared/_Header.cshtml
@@ -49,20 +49,11 @@
             </a>
         </div>
         <div class="dfe-header__content" id="content-header">
-            <ul class="dfe-header__action-links">
-                @{
-                    if (Context.User.Identity?.IsAuthenticated == true)
-                    {
-                        <li>
-                            <a asp-controller="Auth" asp-action="SignOut" class="govuk-link govuk-link--inverse">Sign out</a>
-                        </li>
-                    }
-                }
-            </ul>
+            
         </div>
     </div>
     <div class="dfe-width-container dfe-header__service-name">
-        <a href="/" class="dfe-header__link--service">@Model.ServiceName</a>
+        @Model.ServiceName
     </div>
     @{ await Html.RenderPartialAsync("Navigation"); }
 </header>

--- a/src/web/CareLeavers.Web/Views/Shared/_Layout.cshtml
+++ b/src/web/CareLeavers.Web/Views/Shared/_Layout.cshtml
@@ -67,9 +67,11 @@
         </script>
         <!-- End Clarity -->
     }
-    <!-- Begin ShareThis -->
-    <script type="text/javascript" asp-add-nonce="true" src="https://platform-api.sharethis.com/js/sharethis.js#property=@scriptConfig.ShareThis&product=inline-share-buttons&source=platform" async="async"></script>
-    <!-- End ShareThis -->
+    <!-- BEGIN SHAREAHOLIC CODE -->
+    <link rel="preload" href="https://cdn.shareaholic.net/assets/pub/shareaholic.js" as="script" />
+    <meta name="shareaholic:site_id" content="@scriptConfig.ShareaholicSiteId" />
+    <script asp-add-nonce="true" data-cfasync="false" async src="https://cdn.shareaholic.net/assets/pub/shareaholic.js"></script>
+    <!-- END SHAREAHOLIC CODE -->
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <title>@ViewData["Title"] - @config.ServiceName</title>

--- a/src/web/CareLeavers.Web/Views/Shared/_Layout.cshtml
+++ b/src/web/CareLeavers.Web/Views/Shared/_Layout.cshtml
@@ -1,5 +1,4 @@
-﻿@using System.Globalization
-@using CareLeavers.Web.Configuration
+﻿@using CareLeavers.Web.Configuration
 @using GovUk.Frontend.AspNetCore
 @using GovUk.Frontend.AspNetCore.TagHelpers
 @using Joonasw.AspNetCore.SecurityHeaders.Csp

--- a/src/web/CareLeavers.Web/appsettings.json
+++ b/src/web/CareLeavers.Web/appsettings.json
@@ -35,43 +35,43 @@
   },
   "Csp": {
     "AllowScriptUrls": [
-      "https://cdn.openshareweb.com",
-      "https://cdn.openshareweb.net",
-      "https://cdn.shareaholic.net",
-      "https://partner.shareaholic.com",
-      "https://*.googletagmanager.com",
-      "https://*.clarity.ms",
-      "https://c.bing.com"
+      "cdn.openshareweb.com",
+      "cdn.openshareweb.net",
+      "cdn.shareaholic.net",
+      "partner.shareaholic.com",
+      "*.googletagmanager.com",
+      "*.clarity.ms",
+      "c.bing.com"
     ],
     "AllowStyleUrls": [
-      "https://cdn.openshareweb.com",
-      "https://rsms.me"
+      "cdn.openshareweb.com",
+      "rsms.me"
     ],
     "AllowFontUrls": [
-      "https://rsms.me",
-      "https://cdn.openshareweb.net",
-      "https://cdn.openshareweb.com"
+      "rsms.me",
+      "cdn.openshareweb.net",
+      "cdn.openshareweb.com"
     ],
     "AllowFrameUrls": [
       "*.googletagmanager.com",
       "app.contentful.com"   
     ],
     "AllowImageUrls": [
-      "https://cdn.openshareweb.com",
-      "https://cdn.openshareweb.net",
-      "https://images.ctfassets.net",
-      "https://*.googletagmanager.com",
-      "https://*.google-analytics.com"
+      "cdn.openshareweb.com",
+      "cdn.openshareweb.net",
+      "images.ctfassets.net",
+      "*.googletagmanager.com",
+      "*.google-analytics.com"
     ],
     "AllowConnectUrls": [
-      "https://*.shareaholic.com",
-      "https://*.shareaholic.net",
-      "https://cdn.openshareweb.com",
-      "https://*.clarity.ms",
-      "https://c.bing.com",
-      "https://*.googletagmanager.com",
-      "https://*.google-analytics.com",
-      "https://*.analytics.google.com"
+      "*.shareaholic.com",
+      "*.shareaholic.net",
+      "cdn.openshareweb.com",
+      "*.clarity.ms",
+      "c.bing.com",
+      "*.googletagmanager.com",
+      "*.google-analytics.com",
+      "*.analytics.google.com"
     ]
   }
 }

--- a/src/web/CareLeavers.Web/appsettings.json
+++ b/src/web/CareLeavers.Web/appsettings.json
@@ -17,7 +17,8 @@
   "Scripts": {
     "GTM": "GTM-M2CBTMTD",
     "Clarity": "",
-    "ShareThis": "67a9d0adc7696f001258a34a",
+    "ShareaholicSiteId": "253deae28d2ec5780832d84b7949b5cf",
+    "ShareaholicAppId": "33246672",
     "ShowCookieBanner": true
   },
   "Caching": {
@@ -34,33 +35,43 @@
   },
   "Csp": {
     "AllowScriptUrls": [
-      "*.sharethis.com",
-      "*.googletagmanager.com",
-      "*.clarity.ms",
-      "c.bing.com"
+      "https://cdn.openshareweb.com",
+      "https://cdn.openshareweb.net",
+      "https://cdn.shareaholic.net",
+      "https://partner.shareaholic.com",
+      "https://*.googletagmanager.com",
+      "https://*.clarity.ms",
+      "https://c.bing.com"
     ],
     "AllowStyleUrls": [
-      "*.sharethis.com",
-      "rsms.me"
+      "https://cdn.openshareweb.com",
+      "https://rsms.me"
     ],
-    "AllowFontUrls": ["rsms.me"],
+    "AllowFontUrls": [
+      "https://rsms.me",
+      "https://cdn.openshareweb.net",
+      "https://cdn.openshareweb.com"
+    ],
     "AllowFrameUrls": [
       "*.googletagmanager.com",
       "app.contentful.com"   
     ],
     "AllowImageUrls": [
-      "*.sharethis.com",
-      "images.ctfassets.net",
-      "*.googletagmanager.com",
-      "*.google-analytics.com"
+      "https://cdn.openshareweb.com",
+      "https://cdn.openshareweb.net",
+      "https://images.ctfassets.net",
+      "https://*.googletagmanager.com",
+      "https://*.google-analytics.com"
     ],
     "AllowConnectUrls": [
-      "*.sharethis.com",
-      "*.clarity.ms",
-      "c.bing.com",
-      "*.googletagmanager.com",
-      "*.google-analytics.com",
-      "*.analytics.google.com"
+      "https://*.shareaholic.com",
+      "https://*.shareaholic.net",
+      "https://cdn.openshareweb.com",
+      "https://*.clarity.ms",
+      "https://c.bing.com",
+      "https://*.googletagmanager.com",
+      "https://*.google-analytics.com",
+      "https://*.analytics.google.com"
     ]
   }
 }

--- a/src/web/tests/CareLeavers.Integration.Tests/TestSupport/IntegrationTestWebFactory.cs
+++ b/src/web/tests/CareLeavers.Integration.Tests/TestSupport/IntegrationTestWebFactory.cs
@@ -54,7 +54,8 @@ public class IntegrationTestWebFactory : WebApplicationFactory<Program>
             {
                 Clarity = "test-clarity",
                 GTM = "GTM-TEST",
-                ShareThis = "abcdefghijk",
+                ShareaholicSiteId = "abcdefghijk",
+                ShareaholicAppId = "12345678",
                 ShowCookieBanner = false,
                 AddCssVersion = false
             }));

--- a/src/web/tests/CareLeavers.Integration.Tests/Tests/ContentfulControllerTests.cs
+++ b/src/web/tests/CareLeavers.Integration.Tests/Tests/ContentfulControllerTests.cs
@@ -1,6 +1,5 @@
 using System.Net;
 using System.Xml;
-using CareLeavers.Integration.Tests.TestSupport;
 
 namespace CareLeavers.Integration.Tests.Tests;
 

--- a/src/web/tests/CareLeavers.Integration.Tests/Tests/SnapshotTests/Output/HomePageWithSupport.html
+++ b/src/web/tests/CareLeavers.Integration.Tests/Tests/SnapshotTests/Output/HomePageWithSupport.html
@@ -130,7 +130,7 @@
 								<div class="govuk-grid-column-two-thirds">
 									<h2 class="govuk-heading-l" id="Who-is-this-support-for-">Who is this support for?</h2>
 									<p class="govuk-body">You might have the right to leaving care support if you:</p>
-									<ul>
+									<ul class="govuk-list govuk-list--bullet">
 										<li>are aged 15 to 24</li>
 										<li>have spent time in care in England</li>
 										<li>
@@ -138,7 +138,7 @@
 										</li>
 									</ul>
 									<p class="govuk-body">This includes:</p>
-									<ul>
+									<ul class="govuk-list govuk-list--bullet">
 										<li>foster care</li>
 										<li>residential care (like a children’s home)</li>
 										<li>time in custody (like a young offender institution or secure children’s home)</li>

--- a/src/web/tests/CareLeavers.Integration.Tests/Tests/SnapshotTests/Output/HomePageWithSupport.html
+++ b/src/web/tests/CareLeavers.Integration.Tests/Tests/SnapshotTests/Output/HomePageWithSupport.html
@@ -62,18 +62,16 @@
 					</button>
 				</div>
 				<div class="dfe-header__logo">
-					<a class="dfe-header__link dfe-header__link--service " href="/" aria-label="DfE homepage">
-						<img src="/assets/dfe-logo.png" class="dfe-logo" alt="DfE Homepage">
-						<img src="/assets/dfe-logo-alt.png" class="dfe-logo-hover" alt="DfE Homepage">
+					<a class="dfe-header__link dfe-header__link--service " href="/" aria-label="Care leavers homepage">
+						<img src="/assets/dfe-logo.png" class="dfe-logo" alt="Care leavers homepage">
+						<img src="/assets/dfe-logo-alt.png" class="dfe-logo-hover" alt="Care leavers homepage">
 					</a>
 				</div>
 				<div class="dfe-header__content" id="content-header">
-					<ul class="dfe-header__action-links">
-					</ul>
 				</div>
 			</div>
 			<div class="dfe-width-container dfe-header__service-name">
-				<a href="/" class="dfe-header__link--service">Care leavers</a>
+				Care leavers
 			</div>
 			<nav class="dfe-header__navigation" id="header-navigation" role="navigation" aria-label="Primary navigation" aria-labelledby="label-navigation">
 				<div class="dfe-width-container">
@@ -253,9 +251,7 @@
 							<div class="govuk-!-margin-top-3 govuk-!-margin-bottom-5">
 								<div class="govuk-grid-row split-panel" style="background: #f3f2f1; vertical-align: text-top;">
 									<div class="govuk-grid-column-one-half image-column">
-										<a href="guide-leaving-care" class="govuk-link">
-											<div class="image-container" style="background-image: url('//images.ctfassets.net/3y72rykjd1o5/3AJ5VJg0WfmJImY90KOpQU/39af1e2a663401b7607b9fac86c50d1e/image.png');"></div>
-										</a>
+										<div class="image-container" style="background-image: url('//images.ctfassets.net/3y72rykjd1o5/3AJ5VJg0WfmJImY90KOpQU/39af1e2a663401b7607b9fac86c50d1e/image.png');"></div>
 									</div>
 									<div class="govuk-grid-column-one-half text-column">
 										<span class="govuk-caption-l">Guide</span>

--- a/src/web/tests/CareLeavers.Integration.Tests/Tests/SnapshotTests/Output/HomePageWithSupport.html
+++ b/src/web/tests/CareLeavers.Integration.Tests/Tests/SnapshotTests/Output/HomePageWithSupport.html
@@ -17,10 +17,12 @@
 		</script>
 		
 		<!-- End Clarity -->     
-		<!-- Begin ShareThis -->
-		<script type="text/javascript" src="https://platform-api.sharethis.com/js/sharethis.js#property=abcdefghijk&amp;product=inline-share-buttons&amp;source=platform" async="async" nonce="mock-nonce"></script>
+		<!-- BEGIN SHAREAHOLIC CODE -->
+		<link rel="preload" href="https://cdn.shareaholic.net/assets/pub/shareaholic.js" as="script">
+		<meta name="shareaholic:site_id" content="abcdefghijk">
+		<script data-cfasync="false" async="" src="https://cdn.shareaholic.net/assets/pub/shareaholic.js" nonce="mock-nonce"></script>
 		
-		<!-- End ShareThis -->
+		<!-- END SHAREAHOLIC CODE -->
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
 		<title>Find support for care leavers - Care leavers</title>

--- a/src/web/tests/CareLeavers.Integration.Tests/Tests/SnapshotTests/Output/PageWithBanner.html
+++ b/src/web/tests/CareLeavers.Integration.Tests/Tests/SnapshotTests/Output/PageWithBanner.html
@@ -17,10 +17,12 @@
 		</script>
 		
 		<!-- End Clarity -->     
-		<!-- Begin ShareThis -->
-		<script type="text/javascript" src="https://platform-api.sharethis.com/js/sharethis.js#property=abcdefghijk&amp;product=inline-share-buttons&amp;source=platform" async="async" nonce="mock-nonce"></script>
+		<!-- BEGIN SHAREAHOLIC CODE -->
+		<link rel="preload" href="https://cdn.shareaholic.net/assets/pub/shareaholic.js" as="script">
+		<meta name="shareaholic:site_id" content="abcdefghijk">
+		<script data-cfasync="false" async="" src="https://cdn.shareaholic.net/assets/pub/shareaholic.js" nonce="mock-nonce"></script>
 		
-		<!-- End ShareThis -->
+		<!-- END SHAREAHOLIC CODE -->
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
 		<title>Work and employment support - Care leavers</title>

--- a/src/web/tests/CareLeavers.Integration.Tests/Tests/SnapshotTests/Output/PageWithBanner.html
+++ b/src/web/tests/CareLeavers.Integration.Tests/Tests/SnapshotTests/Output/PageWithBanner.html
@@ -62,18 +62,16 @@
 					</button>
 				</div>
 				<div class="dfe-header__logo">
-					<a class="dfe-header__link dfe-header__link--service " href="/" aria-label="DfE homepage">
-						<img src="/assets/dfe-logo.png" class="dfe-logo" alt="DfE Homepage">
-						<img src="/assets/dfe-logo-alt.png" class="dfe-logo-hover" alt="DfE Homepage">
+					<a class="dfe-header__link dfe-header__link--service " href="/" aria-label="Care leavers homepage">
+						<img src="/assets/dfe-logo.png" class="dfe-logo" alt="Care leavers homepage">
+						<img src="/assets/dfe-logo-alt.png" class="dfe-logo-hover" alt="Care leavers homepage">
 					</a>
 				</div>
 				<div class="dfe-header__content" id="content-header">
-					<ul class="dfe-header__action-links">
-					</ul>
 				</div>
 			</div>
 			<div class="dfe-width-container dfe-header__service-name">
-				<a href="/" class="dfe-header__link--service">Care leavers</a>
+				Care leavers
 			</div>
 			<nav class="dfe-header__navigation" id="header-navigation" role="navigation" aria-label="Primary navigation" aria-labelledby="label-navigation">
 				<div class="dfe-width-container">

--- a/src/web/tests/CareLeavers.Integration.Tests/Tests/SnapshotTests/Output/PageWithBanner.html
+++ b/src/web/tests/CareLeavers.Integration.Tests/Tests/SnapshotTests/Output/PageWithBanner.html
@@ -162,7 +162,7 @@
 						<h3 class="govuk-heading-m" id="Local-support">Local support</h3>
 						<p class="govuk-body">You might get support from your local council’s Local Offer for care leavers</p>
 						<p class="govuk-body">For example, this could include things like:</p>
-						<ul>
+						<ul class="govuk-list govuk-list--bullet">
 							<li>help with travel costs (like a bus pass) or essential clothes for work or interviews</li>
 							<li>careers advice and guidance, such as help with job searches or writing your CV</li>
 							<li>work experience or an apprenticeship at your council</li>

--- a/src/web/tests/CareLeavers.Integration.Tests/Tests/SnapshotTests/Output/PageWithBanner.html
+++ b/src/web/tests/CareLeavers.Integration.Tests/Tests/SnapshotTests/Output/PageWithBanner.html
@@ -237,7 +237,7 @@
 						<div class="govuk-grid-row">
 							<div class="govuk-grid-column-full">
 								<h3 class="govuk-heading-m">Share this page</h3>
-								<div class="sharethis-inline-share-buttons"></div>
+								<div class="shareaholic-canvas" data-app="share_buttons" data-app-id="12345678"></div>
 							</div>
 						</div>
 					</div>

--- a/src/web/tests/CareLeavers.Integration.Tests/Tests/SnapshotTests/Output/SimpleAsset.html
+++ b/src/web/tests/CareLeavers.Integration.Tests/Tests/SnapshotTests/Output/SimpleAsset.html
@@ -62,18 +62,16 @@
 					</button>
 				</div>
 				<div class="dfe-header__logo">
-					<a class="dfe-header__link dfe-header__link--service " href="/" aria-label="DfE homepage">
-						<img src="/assets/dfe-logo.png" class="dfe-logo" alt="DfE Homepage">
-						<img src="/assets/dfe-logo-alt.png" class="dfe-logo-hover" alt="DfE Homepage">
+					<a class="dfe-header__link dfe-header__link--service " href="/" aria-label="Care leavers homepage">
+						<img src="/assets/dfe-logo.png" class="dfe-logo" alt="Care leavers homepage">
+						<img src="/assets/dfe-logo-alt.png" class="dfe-logo-hover" alt="Care leavers homepage">
 					</a>
 				</div>
 				<div class="dfe-header__content" id="content-header">
-					<ul class="dfe-header__action-links">
-					</ul>
 				</div>
 			</div>
 			<div class="dfe-width-container dfe-header__service-name">
-				<a href="/" class="dfe-header__link--service">Care leavers</a>
+				Care leavers
 			</div>
 			<nav class="dfe-header__navigation" id="header-navigation" role="navigation" aria-label="Primary navigation" aria-labelledby="label-navigation">
 				<div class="dfe-width-container">

--- a/src/web/tests/CareLeavers.Integration.Tests/Tests/SnapshotTests/Output/SimpleAsset.html
+++ b/src/web/tests/CareLeavers.Integration.Tests/Tests/SnapshotTests/Output/SimpleAsset.html
@@ -17,10 +17,12 @@
 		</script>
 		
 		<!-- End Clarity -->     
-		<!-- Begin ShareThis -->
-		<script type="text/javascript" src="https://platform-api.sharethis.com/js/sharethis.js#property=abcdefghijk&amp;product=inline-share-buttons&amp;source=platform" async="async" nonce="mock-nonce"></script>
+		<!-- BEGIN SHAREAHOLIC CODE -->
+		<link rel="preload" href="https://cdn.shareaholic.net/assets/pub/shareaholic.js" as="script">
+		<meta name="shareaholic:site_id" content="abcdefghijk">
+		<script data-cfasync="false" async="" src="https://cdn.shareaholic.net/assets/pub/shareaholic.js" nonce="mock-nonce"></script>
 		
-		<!-- End ShareThis -->
+		<!-- END SHAREAHOLIC CODE -->
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
 		<title>Image Test - Care leavers</title>


### PR DESCRIPTION
### Why?
Improvements off the back of our accessibility audit

### Changes from accessibility report
- ATI 1 
  - Ensured that category cards are now correctly keyboard accessible and show as focused
- ATI 3
  - Removed empty unordered list
- ATI 4
  - Removed the link from the service name
  - Updated DfE logo aria text and alt text to inform that the image links back to the homepage of the site
- ATI 5
  - Moved from ShareThis to Shareaholic, which supports keyboard navigation
- ATI 6
  - Removed the link from the alternating image card, as it is superfluous and causes screen readers to read the link twice
- ATI 7
  - This should now be resolved with the caching updates made yesterday

### Bonus Changes
- Made telephone links clickable on helplines page