### PR TITLE
Fix SEO and Indexing, plus a Language bug

### DIFF
--- a/src/web/CareLeavers.Web/Controllers/ContentfulController.cs
+++ b/src/web/CareLeavers.Web/Controllers/ContentfulController.cs
@@ -103,17 +103,21 @@ public class ContentfulController(IContentService contentService, ITranslationSe
             return RedirectToAction("GetContent", new { slug, languageCode = "en" });
         }
 
+        var config = await contentService.GetConfiguration();
         var languages = new List<string>();
-        if ((await contentService.GetConfiguration()).TranslationEnabled)
+        if (config is { TranslationEnabled: true })
         {
             languages.AddRange((await translationService.GetLanguages()).Select(l => l.Code));
-
-            if (!languages.Contains(languageCode))
-            {
-                return RedirectToAction("GetContent", new { slug, languageCode = "en" });
-            }
+        }
+        else
+        {
+            languages.Add("en");
         }
         
+        if (!languages.Contains(languageCode))
+        {
+            return RedirectToAction("GetContent", new { slug, languageCode = "en" });
+        }
         
         var page = await contentService.GetPage(slug);
 

--- a/src/web/CareLeavers.Web/Controllers/ContentfulController.cs
+++ b/src/web/CareLeavers.Web/Controllers/ContentfulController.cs
@@ -3,6 +3,7 @@ using CareLeavers.Web.Configuration;
 using CareLeavers.Web.Contentful;
 using CareLeavers.Web.Models.Content;
 using CareLeavers.Web.Filters;
+using CareLeavers.Web.Translation;
 using Contentful.Core.Models;
 using Microsoft.AspNetCore.Mvc;
 using Newtonsoft.Json;
@@ -10,7 +11,7 @@ using Newtonsoft.Json;
 namespace CareLeavers.Web.Controllers;
 
 [Route("/")]
-public class ContentfulController(IContentService contentService) : Controller
+public class ContentfulController(IContentService contentService, ITranslationService translationService) : Controller
 {
     [Route("/")]
     public async Task<IActionResult> Homepage(
@@ -101,6 +102,18 @@ public class ContentfulController(IContentService contentService) : Controller
         {
             return RedirectToAction("GetContent", new { slug, languageCode = "en" });
         }
+
+        var languages = new List<string>();
+        if ((await contentService.GetConfiguration()).TranslationEnabled)
+        {
+            languages.AddRange((await translationService.GetLanguages()).Select(l => l.Code));
+
+            if (!languages.Contains(languageCode))
+            {
+                return RedirectToAction("GetContent", new { slug, languageCode = "en" });
+            }
+        }
+        
         
         var page = await contentService.GetPage(slug);
 

--- a/src/web/CareLeavers.Web/Controllers/RobotsController.cs
+++ b/src/web/CareLeavers.Web/Controllers/RobotsController.cs
@@ -35,7 +35,7 @@ public class RobotsController (IContentfulConfiguration contentfulConfiguration,
         
         sb.AppendLine("Allow: /");
         sb.AppendLine();
-        sb.AppendLine($"Sitemap: {Url.ActionLink("Sitemap", "Sitemap", protocol: "https")}");
+        sb.AppendLine($"Sitemap: {Url.ActionLink(action: "Sitemap", controller: "Sitemap", protocol: "https")}");
         
         return Content(sb.ToString(), "text/plain");
     }

--- a/src/web/CareLeavers.Web/Controllers/RobotsController.cs
+++ b/src/web/CareLeavers.Web/Controllers/RobotsController.cs
@@ -1,26 +1,41 @@
 using System.Text;
+using CareLeavers.Web.Configuration;
+using CareLeavers.Web.Translation;
 using Microsoft.AspNetCore.Mvc;
 
 namespace CareLeavers.Web.Controllers;
 
-public class RobotsController : Controller
+public class RobotsController (IContentfulConfiguration contentfulConfiguration, ITranslationService translationService) : Controller
 {
     [Route("/robots.txt")]
-    public IActionResult Robots()
+    public async Task<IActionResult> Robots()
     {
         if (!ModelState.IsValid)
         {
             return BadRequest();
         }
 
+        var config = await contentfulConfiguration.GetConfiguration();
+        var languages = new List<TranslationLanguage>();
+        if (config.TranslationEnabled)
+        {
+            languages.AddRange(await translationService.GetLanguages());
+        }
         
         StringBuilder sb = new StringBuilder();
 
         sb.AppendLine("User-agent: *");
         sb.AppendLine("Disallow: /translation");
+        sb.AppendLine("Disallow: /en/404");
+
+        foreach (var language in languages.Where(l => !l.Code.Equals("en", StringComparison.InvariantCultureIgnoreCase)))
+        {
+            sb.AppendLine($"Disallow: /{language.Code}/");
+        }
+        
         sb.AppendLine("Allow: /");
         sb.AppendLine();
-        sb.AppendLine($"Sitemap: {Url.ActionLink("Sitemap", "Sitemap")}");
+        sb.AppendLine($"Sitemap: {Url.ActionLink("Sitemap", "Sitemap", protocol: "https")}");
         
         return Content(sb.ToString(), "text/plain");
     }

--- a/src/web/CareLeavers.Web/Filters/ContentfulCachingAttribute.cs
+++ b/src/web/CareLeavers.Web/Filters/ContentfulCachingAttribute.cs
@@ -23,16 +23,24 @@ public class TranslationAttribute : ActionFilterAttribute
         _originalBodyStream = null;
 
         var distributedCache = context.HttpContext.RequestServices.GetRequiredService<IDistributedCache>();
+        var translationService = context.HttpContext.RequestServices.GetRequiredService<ITranslationService>();
         var contentfulConfiguration = context.HttpContext.RequestServices.GetRequiredService<IContentfulConfiguration>();
         var config = await contentfulConfiguration.GetConfiguration();
 
         var slug = HardcodedSlug ?? context.RouteData.Values["slug"]?.ToString();
         var languageCode = context.RouteData.Values["languageCode"]?.ToString();
+        var languages = new List<string>();
+        if (config.TranslationEnabled)
+        {
+            languages.AddRange((await translationService.GetLanguages()).Select(l => l.Code));
+        }
 
         if (slug == null || 
+            !config.TranslationEnabled ||
             string.IsNullOrEmpty(languageCode) || 
             languageCode == "en" ||
-            !config.TranslationEnabled)
+            !languages.Contains(languageCode)
+            )
         {
             await base.OnActionExecutionAsync(context, next);
             return;
@@ -65,14 +73,22 @@ public class TranslationAttribute : ActionFilterAttribute
         await base.OnResultExecutionAsync(context, next);
         
         var translationService = context.HttpContext.RequestServices.GetRequiredService<ITranslationService>();
-
+        var contentfulConfiguration = context.HttpContext.RequestServices.GetRequiredService<IContentfulConfiguration>();
+        var config = await contentfulConfiguration.GetConfiguration();
+        
         var slug = HardcodedSlug ?? context.RouteData.Values["slug"]?.ToString();
         var languageCode = context.RouteData.Values["languageCode"]?.ToString();
+        var languages = new List<string>();
+        if (config.TranslationEnabled)
+        {
+            languages.AddRange((await translationService.GetLanguages()).Select(l => l.Code));
+        }
 
         if (slug == null || 
             string.IsNullOrEmpty(languageCode) || 
             _memoryStream == null || 
-            _originalBodyStream == null)
+            _originalBodyStream == null || 
+            !languages.Contains(languageCode))
         {
             return;
         }

--- a/src/web/CareLeavers.Web/Filters/ContentfulCachingAttribute.cs
+++ b/src/web/CareLeavers.Web/Filters/ContentfulCachingAttribute.cs
@@ -34,7 +34,11 @@ public class TranslationAttribute : ActionFilterAttribute
         {
             languages.AddRange((await translationService.GetLanguages()).Select(l => l.Code));
         }
-
+        else
+        {
+            languages.Add("en");
+        }
+        
         if (slug == null || 
             !config.TranslationEnabled ||
             string.IsNullOrEmpty(languageCode) || 
@@ -82,6 +86,10 @@ public class TranslationAttribute : ActionFilterAttribute
         if (config.TranslationEnabled)
         {
             languages.AddRange((await translationService.GetLanguages()).Select(l => l.Code));
+        }
+        else
+        {
+            languages.Add("en");
         }
 
         if (slug == null || 

--- a/src/web/CareLeavers.Web/Views/Contentful/Page.cshtml
+++ b/src/web/CareLeavers.Web/Views/Contentful/Page.cshtml
@@ -27,11 +27,11 @@
     <meta property="og:title" content="@(!string.IsNullOrEmpty(Model.SeoTitle) ? Model.SeoTitle : Model.Title)"/>
     <meta property="og:type" content="website"/>
     <meta property="og:url" content="@Url.Action(
-                                         action: "GetContent", 
-                                         controller: "Contentful", 
+                                         action: "GetContent",
+                                         controller: "Contentful",
                                          protocol: "https",
                                          values: new { slug = Model.Slug, language = languageCode }
-                                         )"/>
+                                     )"/>
     @if (Model.SeoImage != null)
     {
         <meta property="og:image" content="@Model.SeoImage.File.Url"/>
@@ -40,11 +40,18 @@
         <meta property="og:image:height" content="@Model.SeoImage.File.Details.Image.Height"/>
         <meta property="og:image:alt" content="@Model.SeoImage.Description"/>
     }
-    <meta property="og:locale" content="@languageCode"/>
+    <meta property="og:locale" content="@(languageCode == "en" ? "en_GB" : languageCode)"/>
     @if (!string.IsNullOrEmpty(Model.SeoDescription))
     {
         <meta property="og:description" content="@Model.SeoDescription"/>
     }
+
+    <link rel="canonical" href="@Url.Action(
+                                    action: "GetContent",
+                                    controller: "Contentful",
+                                    protocol: "https",
+                                    values: new { slug = Model.Slug, language = "en" }
+                                )"/>
 
 }
 

--- a/src/web/CareLeavers.Web/Views/Translation/Index.cshtml
+++ b/src/web/CareLeavers.Web/Views/Translation/Index.cshtml
@@ -6,7 +6,10 @@
 }
 @section Head
 {
-    <meta name="robots" content="noindex, nofollow" />
+    <meta name="robots" content="noindex, nofollow"/>
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate"/>
+    <meta http-equiv="Pragma" content="no-cache"/>
+    <meta http-equiv="Expires" content="0"/>
 }
 
 @section BeforeGDSContent

--- a/src/web/CareLeavers.Web/appsettings.json
+++ b/src/web/CareLeavers.Web/appsettings.json
@@ -17,8 +17,8 @@
   "Scripts": {
     "GTM": "GTM-M2CBTMTD",
     "Clarity": "",
-    "ShareaholicSiteId": "253deae28d2ec5780832d84b7949b5cf",
-    "ShareaholicAppId": "33246672",
+    "ShareaholicSiteId": "b26c912314bafd69e7420c2c227daaf9",
+    "ShareaholicAppId": "33247611",
     "ShowCookieBanner": true
   },
   "Caching": {

--- a/src/web/tests/CareLeavers.Integration.Tests/Tests/SnapshotTests/Output/HomePageWithSupport.html
+++ b/src/web/tests/CareLeavers.Integration.Tests/Tests/SnapshotTests/Output/HomePageWithSupport.html
@@ -37,7 +37,8 @@
 		<meta property="og:title" content="Find support for care leavers">
 		<meta property="og:type" content="website">
 		<meta property="og:url" content="https://localhost/en/home?language=en">
-		<meta property="og:locale" content="en">
+		<meta property="og:locale" content="en_GB">
+		<link rel="canonical" href="https://localhost/en/home?language=en">
 	</head>
 	<body class="govuk-template__body">
 		<script nonce="mock-nonce">document.body.className += ' js-enabled' + ('noModule' in HTMLScriptElement.prototype ? ' govuk-frontend-supported' : '');</script>

--- a/src/web/tests/CareLeavers.Integration.Tests/Tests/SnapshotTests/Output/PageWithBanner.html
+++ b/src/web/tests/CareLeavers.Integration.Tests/Tests/SnapshotTests/Output/PageWithBanner.html
@@ -37,7 +37,8 @@
 		<meta property="og:title" content="Work and employment support">
 		<meta property="og:type" content="website">
 		<meta property="og:url" content="https://localhost/en/work-and-employment-support?language=en">
-		<meta property="og:locale" content="en">
+		<meta property="og:locale" content="en_GB">
+		<link rel="canonical" href="https://localhost/en/work-and-employment-support?language=en">
 	</head>
 	<body class="govuk-template__body">
 		<script nonce="mock-nonce">document.body.className += ' js-enabled' + ('noModule' in HTMLScriptElement.prototype ? ' govuk-frontend-supported' : '');</script>

--- a/src/web/tests/CareLeavers.Integration.Tests/Tests/SnapshotTests/Output/SimpleAsset.html
+++ b/src/web/tests/CareLeavers.Integration.Tests/Tests/SnapshotTests/Output/SimpleAsset.html
@@ -37,7 +37,8 @@
 		<meta property="og:title" content="Image Test">
 		<meta property="og:type" content="website">
 		<meta property="og:url" content="https://localhost/en/image-test?language=en">
-		<meta property="og:locale" content="en">
+		<meta property="og:locale" content="en_GB">
+		<link rel="canonical" href="https://localhost/en/image-test?language=en">
 	</head>
 	<body class="govuk-template__body">
 		<script nonce="mock-nonce">document.body.className += ' js-enabled' + ('noModule' in HTMLScriptElement.prototype ? ' govuk-frontend-supported' : '');</script>

--- a/src/web/tests/CareLeavers.Web.Tests/Controllers/ContentfulControllerTests.cs
+++ b/src/web/tests/CareLeavers.Web.Tests/Controllers/ContentfulControllerTests.cs
@@ -1,5 +1,6 @@
 using CareLeavers.Web.Contentful;
 using CareLeavers.Web.Controllers;
+using CareLeavers.Web.Translation;
 using Microsoft.AspNetCore.Mvc;
 using NSubstitute;
 
@@ -11,8 +12,9 @@ public class ContentfulControllerTests
     public async Task HomePageRedirectsToHomeSlug()
     {
         var contentService = Substitute.For<IContentService>();
+        var translationService = Substitute.For<ITranslationService>();
         
-        var controller = new ContentfulController(contentService);
+        var controller = new ContentfulController(contentService, translationService);
         
         var result = await controller.Homepage(new MockContentfulConfiguration());
         

--- a/src/web/tests/CareLeavers.Web.Tests/MockContentfulConfiguration.cs
+++ b/src/web/tests/CareLeavers.Web.Tests/MockContentfulConfiguration.cs
@@ -14,7 +14,8 @@ public class MockContentfulConfiguration : IContentfulConfiguration
             {
                 Slug = "home"
             },
-            ServiceName = "Care leavers"
+            ServiceName = "Care leavers",
+            TranslationEnabled = true
         });
     }
 }


### PR DESCRIPTION
### What's changed?
- Disable/Discourage caching of the translation page
- Added canonical links to de-dupe accidentally indexed pages in other languages
- Disallow indexing of non-english pages in robots.txt
- Updated shareaholic IDs for new service account

### What's fixed?
- A bug where unsupported language codes would crash the site, they now redirect to english