### PR TITLE
Updated to fix padding on blue boxes without breaking homepage layout

### DIFF
--- a/src/web/CareLeavers.Web/AssetSrc/scss/application.scss
+++ b/src/web/CareLeavers.Web/AssetSrc/scss/application.scss
@@ -416,3 +416,7 @@ html
   max-width:100%; width:100%;
   margin: -35px auto 0;
 }
+
+.govuk-grid-column-two-thirds > .govuk-grid-row > .box-ext {
+  margin: 0 15px;
+}

--- a/src/web/CareLeavers.Web/Views/Shared/RichContent/Block.cshtml
+++ b/src/web/CareLeavers.Web/Views/Shared/RichContent/Block.cshtml
@@ -7,7 +7,9 @@
     var block = await ContentService.Hydrate(Model);
 }
 
-    @foreach (var content in block.Entries)
-    {
+<div class="govuk-grid-row">
+     @foreach (var content in block.Entries)
+     {
         <partial name="RichContent/Content" model="@content"/>
     }
+</div>

--- a/src/web/CareLeavers.Web/Views/Shared/RichContent/Content.cshtml
+++ b/src/web/CareLeavers.Web/Views/Shared/RichContent/Content.cshtml
@@ -25,12 +25,8 @@
     }
     else
     {
-        <section class="dfe-section">
-
-            <div class="@width">
-                <gds-contentful-rich-text document="@Model.Content"/>
-            </div>
-
-        </section>
+        <div class="@width">
+            <gds-contentful-rich-text document="@Model.Content"/>
+        </div>
     }
 }

--- a/src/web/tests/CareLeavers.Integration.Tests/Tests/SnapshotTests/Output/HomePageWithSupport.html
+++ b/src/web/tests/CareLeavers.Integration.Tests/Tests/SnapshotTests/Output/HomePageWithSupport.html
@@ -134,7 +134,7 @@
 			<main b-k59dbireqp="" class="govuk-main-wrapper" id="main-content" role="main">
 				<div class="govuk-grid-row" data-last-fetched="2025-03-12T10:31:15">
 					<div class="govuk-grid-column-full">
-						<section class="dfe-section">
+						<div class="govuk-grid-row">
 							<div class="govuk-grid-column-two-thirds">
 								<h2 class="govuk-heading-l" id="Who-is-this-support-for-">Who is this support for?</h2>
 								<p class="govuk-body">You might have the right to leaving care support if you:</p>
@@ -154,13 +154,11 @@
 								</ul>
 								<p class="govuk-body"></p>
 							</div>
-						</section>
-						<section class="dfe-section">
 							<div class="govuk-grid-column-one-third">
 								<img class="full-width-image" src="//images.ctfassets.net/3y72rykjd1o5/7yIkeMXdrDtuh8tGv7Gd0C/97c31314eeb05236314e9b7859f553e9/image.png" alt="Two young women sat outside at a covered table. One is holding a white mug. Both are in their coats">
 								<p class="govuk-body"></p>
 							</div>
-						</section>
+						</div>
 						<h2 class="govuk-heading-l" id="Find-support">Find support</h2>
 						<section class="dfe-section govuk-!-margin-top-5">
 							<div class="dfe-grid-container dfe-grid-container--wider govuk-!-margin-top-5">


### PR DESCRIPTION
Where the front page content translated was longer than the right-hand image, the grids below bunched up, which is incorrect

This was caused by removing a grid row box to fix the blue padding on the "Your rights" page, so this has been worked around too