### PR TITLE
Translation Page Fixes

### DIFF
--- a/src/contentful/CareLeavers.ContentfulMigration/Migrations/0041-add-translation-message-to-config.cjs
+++ b/src/contentful/CareLeavers.ContentfulMigration/Migrations/0041-add-translation-message-to-config.cjs
@@ -1,0 +1,36 @@
+module.exports = function (migration) {
+    const configuration = migration
+        .editContentType("configuration")
+
+    configuration
+        .createField("translationHeader")
+        .name("Translation Header Content")
+        .type("RichText")
+        .localized(false)
+        .required(false)
+        .validations([
+            {
+                enabledMarks: [
+                    "bold",
+                    "italic"
+                ]
+            },
+            {
+                enabledNodeTypes: [
+                    "heading-2",
+                    "heading-3",
+                    "heading-4",
+                    "ordered-list",
+                    "unordered-list",
+                    "embedded-asset-block",
+                    "hyperlink",
+                    "hr"
+                ],
+                message: "Only heading 3, heading 4, ordered list, unordered list, asset, link to Url, and horizontal rule nodes are allowed"
+            }
+        ])
+        .disabled(false)
+        .omitted(false);
+
+    configuration.changeFieldControl("translationHeader", "builtin", "richTextEditor", {});
+};

--- a/src/web/CareLeavers.Web/AssetSrc/scss/application.scss
+++ b/src/web/CareLeavers.Web/AssetSrc/scss/application.scss
@@ -420,3 +420,7 @@ html
 .govuk-grid-column-two-thirds > .govuk-grid-row > .box-ext {
   margin: 2.5em 15px;
 }
+
+.govuk-phase-banner {
+  border-bottom: none;
+}

--- a/src/web/CareLeavers.Web/Models/Content/ContentfulConfigurationEntity.cs
+++ b/src/web/CareLeavers.Web/Models/Content/ContentfulConfigurationEntity.cs
@@ -33,4 +33,7 @@ public class ContentfulConfigurationEntity : ContentfulContent
     public List<string> ExcludeFromTranslation { get; set; } = [];
     
     public Asset? DefaultSeoImage { get; set; }
+    
+    public Document? TranslationHeader { get; set; }
+
 }

--- a/src/web/CareLeavers.Web/Translation/AzureTranslationService.cs
+++ b/src/web/CareLeavers.Web/Translation/AzureTranslationService.cs
@@ -70,7 +70,9 @@ public class AzureTranslationService : ITranslationService
                     Name = l.Value.Name,
                     NativeName = l.Value.NativeName,
                     Direction = l.Value.Directionality is LanguageDirectionality.LeftToRight ? "ltr" : "rtl"
-                }).ToList();
+                })
+                .OrderBy(l => l.Name)
+                .ToList();
         }) ?? [];
     }
 }

--- a/src/web/CareLeavers.Web/Views/Shared/_Layout.cshtml
+++ b/src/web/CareLeavers.Web/Views/Shared/_Layout.cshtml
@@ -90,8 +90,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <title>@ViewData["Title"] - @config.ServiceName</title>
     <link rel="shortcut icon" sizes="16x16 32x32 48x48" href="/assets/images/favicon.svg"/>
-    <link rel="stylesheet" href="~/css/govuk-frontend.min.css" asp-append-version="@scriptConfig.AddCssVersion">
-    <link rel="stylesheet" href="~/css/dfefrontend.css" asp-append-version="@scriptConfig.AddCssVersion"/>
     <link rel="stylesheet" href="~/css/application.css" asp-append-version="@scriptConfig.AddCssVersion"/>
     <link rel="stylesheet" href="~/css/metadata.css" asp-append-version="@scriptConfig.AddCssVersion"/>
     <link rel="stylesheet" href="~/css/navigation.css" asp-append-version="@scriptConfig.AddCssVersion"/>

--- a/src/web/CareLeavers.Web/Views/Translation/Index.cshtml
+++ b/src/web/CareLeavers.Web/Views/Translation/Index.cshtml
@@ -1,8 +1,10 @@
+@using CareLeavers.Web.Configuration
 @model IEnumerable<CareLeavers.Web.Translation.TranslationLanguage>
-
+@inject IContentfulConfiguration ContentfulConfiguration
 @{
-    ViewBag.Title = "Choose a language";
+    ViewBag.Title = "Translate this website";
     Layout = "_Layout";
+    var config = await ContentfulConfiguration.GetConfiguration();
 }
 @section Head
 {
@@ -15,24 +17,42 @@
 @section BeforeGDSContent
 {
     <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
+        <div class="govuk-grid-column-full">
             <h1 class="govuk-heading-xl">
                 @ViewBag.Title
             </h1>
+            <gds-contentful-rich-text document="@config.TranslationHeader" larger-text="true"></gds-contentful-rich-text>
         </div>
     </div>
 }
 
-<ul class="govuk-list">
-@foreach (var translation in Model)
-{
-    <li>
-        @Html.ActionLink(
-            $"{translation.NativeName} ({translation.Name})", 
-            "Homepage", 
-            "Contentful", 
-    new { languageCode = translation.Code }, 
-    new { @class = "govuk-link", rel = "nofollow" })
-    </li>
+@{
+    var count = (double)Model.Count();
+    var columnSize = 1;
+    if (count > 0)
+    {
+        columnSize = (int)Math.Ceiling(count / 3d);
+    }
+    var languageLists = Model.Chunk(columnSize);
 }
-</ul>
+
+<div class="govuk-grid-row">
+    @foreach (var list in languageLists)
+    {
+        <div class="govuk-grid-column-one-third">
+            <ul class="govuk-list">
+                @foreach (var translation in list)
+                {
+                    <li>
+                        @Html.ActionLink(
+                            $"{translation.NativeName} ({translation.Name})",
+                            "Homepage",
+                            "Contentful",
+                            new { languageCode = translation.Code },
+                            new { @class = "govuk-link", rel = "nofollow" })
+                    </li>
+                }
+            </ul>
+        </div>
+    }
+</div>

--- a/src/web/tests/CareLeavers.Integration.Tests/Tests/SnapshotTests/Output/HomePageWithSupport.html
+++ b/src/web/tests/CareLeavers.Integration.Tests/Tests/SnapshotTests/Output/HomePageWithSupport.html
@@ -27,8 +27,6 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
 		<title>Find support for care leavers - Care leavers</title>
 		<link rel="shortcut icon" sizes="16x16 32x32 48x48" href="/assets/images/favicon.svg">
-		<link rel="stylesheet" href="/css/govuk-frontend.min.css">
-		<link rel="stylesheet" href="/css/dfefrontend.css">
 		<link rel="stylesheet" href="/css/application.css">
 		<link rel="stylesheet" href="/css/metadata.css">
 		<link rel="stylesheet" href="/css/navigation.css">

--- a/src/web/tests/CareLeavers.Integration.Tests/Tests/SnapshotTests/Output/PageWithBanner.html
+++ b/src/web/tests/CareLeavers.Integration.Tests/Tests/SnapshotTests/Output/PageWithBanner.html
@@ -27,8 +27,6 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
 		<title>Work and employment support - Care leavers</title>
 		<link rel="shortcut icon" sizes="16x16 32x32 48x48" href="/assets/images/favicon.svg">
-		<link rel="stylesheet" href="/css/govuk-frontend.min.css">
-		<link rel="stylesheet" href="/css/dfefrontend.css">
 		<link rel="stylesheet" href="/css/application.css">
 		<link rel="stylesheet" href="/css/metadata.css">
 		<link rel="stylesheet" href="/css/navigation.css">

--- a/src/web/tests/CareLeavers.Integration.Tests/Tests/SnapshotTests/Output/SimpleAsset.html
+++ b/src/web/tests/CareLeavers.Integration.Tests/Tests/SnapshotTests/Output/SimpleAsset.html
@@ -27,8 +27,6 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
 		<title>Image Test - Care leavers</title>
 		<link rel="shortcut icon" sizes="16x16 32x32 48x48" href="/assets/images/favicon.svg">
-		<link rel="stylesheet" href="/css/govuk-frontend.min.css">
-		<link rel="stylesheet" href="/css/dfefrontend.css">
 		<link rel="stylesheet" href="/css/application.css">
 		<link rel="stylesheet" href="/css/metadata.css">
 		<link rel="stylesheet" href="/css/navigation.css">


### PR DESCRIPTION
Added the following:
- Fix https://dfedigital.atlassian.net/browse/CARE-851
  - Header content for translation page now set via config
  - Translate this site title set in code
- Fix https://dfedigital.atlassian.net/browse/CARE-904
  - Split languages into 3 columns
  - Sorted by latin name
- Removed superfluous blue border from bottom of phase banner
- Fixed CSS to not double-load GDS and DfE, as these are loaded into application.css via Gulp