### PR TITLE
Print, PDF, and Caching Fixes

### DIFF
--- a/.github/workflows/deploy-env.yaml
+++ b/.github/workflows/deploy-env.yaml
@@ -136,6 +136,10 @@ jobs:
       - name: Delete staging slot
         run: az webapp deployment slot delete --name s186${{ vars.ENVIRONMENT_PREFIX }}-cl-web-app-service --resource-group s186${{ vars.ENVIRONMENT_PREFIX }}-cl-web-rg --slot staging
 
-      - name: Flush Redis Cache
-        if: ${{ vars.CACHING_TYPE == 'Redis' }}
-        run: az redis flush --name s186${{ vars.ENVIRONMENT_PREFIX }}-cl-redis-cache --resource-group s186${{ vars.ENVIRONMENT_PREFIX }}-cl-caching-rg --yes
+      - name: Clear Cache
+        id: clear-cache
+        uses: fjogeleit/http-request-action@v1
+        with: 
+          url: 'https://${{ vars.CUSTOM_DOMAIN }}/b0e0dce2-b96d-4b94-a800-63c3ab56e72f'
+          method: 'POST'
+        

--- a/src/contentful/CareLeavers.ContentfulMigration/Migrations/0051-split-share-and-print.cjs
+++ b/src/contentful/CareLeavers.ContentfulMigration/Migrations/0051-split-share-and-print.cjs
@@ -1,0 +1,37 @@
+module.exports = function (migration) {
+    const page = migration
+        .editContentType("page")
+
+    page
+        .createField("showPrintButton")
+        .name("Show Print Button")
+        .type("Boolean")
+        .localized(false)
+        .required(true)
+        .defaultValue({ "en-US": false })
+        .disabled(false)
+        .omitted(false)
+
+    page.moveField("showPrintButton").afterField("showLastUpdated")
+    page.moveField("showShareLinks").afterField("showPrintButton")
+    
+    const editorLayout = page.editEditorLayout()
+    editorLayout.moveField('showPrintButton').toTheBottomOfFieldGroup('layout')
+    editorLayout.moveField('showShareLinks').toTheBottomOfFieldGroup('layout')
+    
+    // Turn on printing and sharing for ALL pages
+    migration.transformEntries({
+        contentType: 'page',
+        from: ['showPrintButton', 'showShareLinks', 'showLastUpdated'],
+        to: ['showPrintButton', 'showShareLinks', 'showLastUpdated'],
+        transformEntryForLocale: function (fromFields, currentLocale) {
+            return {
+                showPrintButton: true,
+                showShareLinks: true,
+                showLastUpdated: true
+            };
+        }
+    })
+    
+    
+};

--- a/src/web/CareLeavers.Web/AssetSrc/scss/print.scss
+++ b/src/web/CareLeavers.Web/AssetSrc/scss/print.scss
@@ -197,5 +197,18 @@
     clear: both;
   }
 
+  // Make link text black and remove underline
+  [href^="/"].govuk-link::after, [href^="http://"].govuk-link::after, [href^="https://"].govuk-link::after {
+    color: #000000;
+    display: inline-block;
+    margin-left: 0.1rem;
+  }
+  
+  // Hide link for relative URLs (same site) and WhatsApp links
+  [href^="/"].govuk-link::after, [href^="https://wa.me/"].govuk-link::after{
+    content: "";
+    font-size: inherit;
+    word-wrap: inherit;
+  }
   
 }

--- a/src/web/CareLeavers.Web/Contentful/ContentfulContentService.cs
+++ b/src/web/CareLeavers.Web/Contentful/ContentfulContentService.cs
@@ -309,6 +309,9 @@ public class ContentfulContentService : IContentService
                 .ToList();
         });
     }
-    
-    
+
+    public async Task FlushCache()
+    {
+        await _fusionCache.ClearAsync(false);
+    }
 }

--- a/src/web/CareLeavers.Web/Contentful/IContentService.cs
+++ b/src/web/CareLeavers.Web/Contentful/IContentService.cs
@@ -26,5 +26,7 @@ public interface IContentService
     Task<bool> IsPageInPrintableCollection(string slug);
     
     Task<bool> IsInPrintableCollection(string id);
-    
+
+    Task FlushCache();
+
 }

--- a/src/web/CareLeavers.Web/Controllers/ContentfulController.cs
+++ b/src/web/CareLeavers.Web/Controllers/ContentfulController.cs
@@ -11,7 +11,7 @@ using Newtonsoft.Json;
 namespace CareLeavers.Web.Controllers;
 
 [Route("/")]
-public class ContentfulController(IContentService contentService, ITranslationService translationService) : Controller
+public class ContentfulController(IContentService contentService, ITranslationService translationService, IHostEnvironment environment) : Controller
 {
     [Route("/")]
     public async Task<IActionResult> Homepage(
@@ -156,11 +156,22 @@ public class ContentfulController(IContentService contentService, ITranslationSe
         return View("Page", page);
     }
 
-    [Route("/flush-cache")]
+    [HttpPost("/b0e0dce2-b96d-4b94-a800-63c3ab56e72f")]
     public async Task<IActionResult> FlushCache()
     {
         await contentService.FlushCache();
 
         return new OkObjectResult("Success");
+    }
+    
+    [HttpPost("clear-cache")]
+    public async Task<IActionResult> FlushCacheOnDev()
+    {
+        if (environment.IsDevelopment())
+        {
+            return await FlushCache();
+        }
+
+        return NotFound();
     }
 }

--- a/src/web/CareLeavers.Web/Controllers/ContentfulController.cs
+++ b/src/web/CareLeavers.Web/Controllers/ContentfulController.cs
@@ -164,7 +164,7 @@ public class ContentfulController(IContentService contentService, ITranslationSe
         return new OkObjectResult("Success");
     }
     
-    [HttpPost("clear-cache")]
+    [HttpGet("clear-cache")]
     public async Task<IActionResult> FlushCacheOnDev()
     {
         if (environment.IsDevelopment())

--- a/src/web/CareLeavers.Web/Controllers/ContentfulController.cs
+++ b/src/web/CareLeavers.Web/Controllers/ContentfulController.cs
@@ -164,7 +164,7 @@ public class ContentfulController(IContentService contentService, ITranslationSe
         return new OkObjectResult("Success");
     }
     
-    [HttpGet("clear-cache")]
+    [HttpGet("flush-cache")]
     public async Task<IActionResult> FlushCacheOnDev()
     {
         if (environment.IsDevelopment())

--- a/src/web/CareLeavers.Web/Controllers/ContentfulController.cs
+++ b/src/web/CareLeavers.Web/Controllers/ContentfulController.cs
@@ -155,6 +155,12 @@ public class ContentfulController(IContentService contentService, ITranslationSe
         
         return View("Page", page);
     }
-    
-    
+
+    [Route("/flush-cache")]
+    public async Task<IActionResult> FlushCache()
+    {
+        await contentService.FlushCache();
+
+        return new OkObjectResult("Success");
+    }
 }

--- a/src/web/CareLeavers.Web/Controllers/PrintController.cs
+++ b/src/web/CareLeavers.Web/Controllers/PrintController.cs
@@ -110,7 +110,8 @@ public class PrintController(IContentService contentService, ITranslationService
 
             if (pdf.Length > 0)
             {
-                return File(pdf, contentType: "application/pdf", fileDownloadName: $"{identifier}.pdf");
+                Response.Headers.Append("Content-Disposition",$"inline;{identifier}.pdf");
+                return File(pdf, contentType: "application/pdf");
             }
         }
         catch (HttpRequestException)

--- a/src/web/CareLeavers.Web/Models/Content/Page.cs
+++ b/src/web/CareLeavers.Web/Models/Content/Page.cs
@@ -15,7 +15,7 @@ public class Page : ContentfulContent
     
     public Asset? SeoImage { get; set; }
 
-    public bool ExcludeFromSitemap { get; set; } = false;
+    public bool ExcludeFromSitemap { get; set; }
     
     public PageWidth Width { get; set; }
     
@@ -25,15 +25,17 @@ public class Page : ContentfulContent
     
     public string? Slug { get; set; }
     
-    public bool ShowBreadcrumb { get; set; } = true;
+    public bool ShowBreadcrumb { get; set; }
 
-    public bool ShowContentsBlock { get; set; } = false;
+    public bool ShowContentsBlock { get; set; }
     
     public HeadingType[] ContentsHeadings { get; set; } = [ ];
 
-    public bool ShowLastUpdated { get; set; } = true;
-    
+    public bool ShowLastUpdated { get; set; }
+
     public bool ShowShareLinks { get; set; }
+
+    public bool ShowPrintButton { get; set; }
     
     public bool ShowFooter { get; set; }
     

--- a/src/web/CareLeavers.Web/Views/Contentful/Page.cshtml
+++ b/src/web/CareLeavers.Web/Views/Contentful/Page.cshtml
@@ -110,8 +110,7 @@
     </div>
     <div class="govuk-grid-column-full">
         <partial name="LastUpdated" model="@Model"/>
-        
-        <partial name="Shareaholic" model="Model"/>
+        <partial name="SharingLinks" model="Model"/>
     </div>
     @if (Model.Width == PageWidth.TwoThirds)
     {

--- a/src/web/CareLeavers.Web/Views/Shared/LastUpdated.cshtml
+++ b/src/web/CareLeavers.Web/Views/Shared/LastUpdated.cshtml
@@ -8,7 +8,7 @@
 
     <div class="govuk-grid-row" id="last-updated">
         <div class="metadata-logo-wrapper">
-            <div class="govuk-grid-column-two-thirds metadata-column">
+            <div class="govuk-grid-column-full metadata-column">
                 <hr class="govuk-section-break govuk-section-break--visible">
                 <div class="gem-c-metadata" data-module="gem-toggle metadata">
                     <dl class="gem-c-metadata__list">
@@ -32,10 +32,7 @@
                         </dd>
                     </dl>
                 </div>
-                @if (Model.ShowShareLinks)
-                {
-                    <partial name="PrintThisPage" model="@Model"/>
-                }
+                <partial name="PrintThisPage" model="@Model"/>
             </div>
         </div>
     </div>

--- a/src/web/CareLeavers.Web/Views/Shared/PrintThisPage.cshtml
+++ b/src/web/CareLeavers.Web/Views/Shared/PrintThisPage.cshtml
@@ -5,24 +5,27 @@
     var languageCode = Context.Request.RouteValues["languageCode"]?.ToString();
 }
 
-<div class="gem-c-print-link govuk-!-display-none-print govuk-!-margin-top-3 govuk-!-margin-bottom-8">
-    <button class="govuk-link govuk-body-s gem-c-print-link__button" data-module="print-link" id="print-link">Print this page</button>
-    
-    @if (await ContentService.IsInPrintableCollection(Model.Sys.Id))
-    {
-        var config = await ContentService.GetConfiguration();
-        var printableCollectionPage = config?.PrintableCollectionPage;
-        var printableCollectionCallToAction = config?.PrintableCollectionCallToAction;
-        if (printableCollectionPage != null && printableCollectionCallToAction != null)
+@if (Model.ShowPrintButton)
+{
+    <div class="gem-c-print-link govuk-!-display-none-print govuk-!-margin-top-3 govuk-!-margin-bottom-8">
+        <button class="govuk-link govuk-body-s gem-c-print-link__button" data-module="print-link" id="print-link">Print this page</button>
+
+        @if (await ContentService.IsInPrintableCollection(Model.Sys.Id))
         {
-            <div class="govuk-!-display-none-print govuk-!-margin-top-4">
-                @Html.ActionLink(
-                    printableCollectionCallToAction, "GetContent", "Contentful", 
-                    routeValues: new { slug = printableCollectionPage.Slug, languageCode }, new
-                    {
-                        @class = "govuk-link"
-                    })
-            </div>
+            var config = await ContentService.GetConfiguration();
+            var printableCollectionPage = config?.PrintableCollectionPage;
+            var printableCollectionCallToAction = config?.PrintableCollectionCallToAction;
+            if (printableCollectionPage != null && printableCollectionCallToAction != null)
+            {
+                <div class="govuk-!-display-none-print govuk-!-margin-top-4">
+                    @Html.ActionLink(
+                        printableCollectionCallToAction, "GetContent", "Contentful",
+                        routeValues: new { slug = printableCollectionPage.Slug, languageCode }, new
+                        {
+                            @class = "govuk-link"
+                        })
+                </div>
+            }
         }
-    }
-</div>
+    </div>
+}

--- a/src/web/CareLeavers.Web/Views/Shared/SharingLinks.cshtml
+++ b/src/web/CareLeavers.Web/Views/Shared/SharingLinks.cshtml
@@ -3,21 +3,21 @@
 @model CareLeavers.Web.Models.Content.Page
 @inject IOptions<ScriptOptions> ScriptOptions
 
+@if (Model is { ShowPrintButton: true, ShowLastUpdated: false })
+{
+    <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible"/>
+    <div class="govuk-grid-row">
+        <div class="metadata-logo-wrapper">
+            <div class="govuk-grid-column-two-thirds metadata-column">
+                <partial name="PrintThisPage" model="@Model"/>
+            </div>
+        </div>
+    </div>
+}
+
 @if (Model.ShowShareLinks)
 {
     var scriptConfig = ScriptOptions.Value;
-
-    if (!Model.ShowLastUpdated)
-    {
-        <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible"/>
-        <div class="govuk-grid-row">
-            <div class="metadata-logo-wrapper">
-                <div class="govuk-grid-column-two-thirds metadata-column">
-                    <partial name="PrintThisPage" model="@Model"/>
-                </div>
-            </div>
-        </div>
-    }
     
     <div class="govuk-grid-row" id="share-this-page">
         <div class="govuk-grid-column-full">

--- a/src/web/tests/CareLeavers.Integration.Tests/Tests/SnapshotTests/Output/PageWithBanner.html
+++ b/src/web/tests/CareLeavers.Integration.Tests/Tests/SnapshotTests/Output/PageWithBanner.html
@@ -206,7 +206,7 @@
 					<div class="govuk-grid-column-full">
 						<div class="govuk-grid-row" id="last-updated">
 							<div class="metadata-logo-wrapper">
-								<div class="govuk-grid-column-two-thirds metadata-column">
+								<div class="govuk-grid-column-full metadata-column">
 									<hr class="govuk-section-break govuk-section-break--visible">
 									<div class="gem-c-metadata" data-module="gem-toggle metadata">
 										<dl class="gem-c-metadata__list">
@@ -225,9 +225,6 @@
 												5 March 2025
 											</dd>
 										</dl>
-									</div>
-									<div class="gem-c-print-link govuk-!-display-none-print govuk-!-margin-top-3 govuk-!-margin-bottom-8">
-										<button class="govuk-link govuk-body-s gem-c-print-link__button" data-module="print-link" id="print-link">Print this page</button>
 									</div>
 								</div>
 							</div>

--- a/src/web/tests/CareLeavers.Integration.Tests/Tests/SnapshotTests/Output/SimpleAsset.html
+++ b/src/web/tests/CareLeavers.Integration.Tests/Tests/SnapshotTests/Output/SimpleAsset.html
@@ -102,13 +102,6 @@
 		</section>
 		<section class="dfe-page-grey" id="main-content-header">
 			<div class="govuk-width-container" id="main-header-container">
-				<nav class="govuk-breadcrumbs" aria-label="Breadcrumb">
-					<ol class="govuk-breadcrumbs__list">
-						<li class="govuk-breadcrumbs__list-item">
-							<a class="govuk-breadcrumbs__link" href="/en/home">Home</a>
-						</li>
-					</ol>
-				</nav>
 				<div class="govuk-grid-row">
 					<div class="govuk-grid-column-two-thirds">
 						<h1 class="govuk-heading-xl">
@@ -126,31 +119,6 @@
 						<p class="govuk-body"></p>
 					</div>
 					<div class="govuk-grid-column-full">
-						<div class="govuk-grid-row" id="last-updated">
-							<div class="metadata-logo-wrapper">
-								<div class="govuk-grid-column-two-thirds metadata-column">
-									<hr class="govuk-section-break govuk-section-break--visible">
-									<div class="gem-c-metadata" data-module="gem-toggle metadata">
-										<dl class="gem-c-metadata__list">
-											<dt class="gem-c-metadata__term">From:</dt>
-											<dd class="gem-c-metadata__definition notranslate">
-												<a class="govuk-link" href="https://www.gov.uk/government/organisations/department-for-education">Department for Education</a>
-											</dd>
-											<dt class="gem-c-metadata__term print-only">Page:</dt>
-											<dd class="gem-c-metadata__definition print-only">Image Test</dd>
-											<dt class="gem-c-metadata__term print-only">URL:</dt>
-											<dd class="gem-c-metadata__definition print-only">https://localhost/en/home</dd>
-											<dt class="gem-c-metadata__term">Published:</dt>
-											<dd class="gem-c-metadata__definition">30 January 2025</dd>
-											<dt class="gem-c-metadata__term">Last updated:</dt>
-											<dd class="gem-c-metadata__definition">
-												30 January 2025
-											</dd>
-										</dl>
-									</div>
-								</div>
-							</div>
-						</div>
 					</div>
 					<div class="govuk-grid-column-one-third"></div>
 					<div class="govuk-grid-column-full" id="secondary-content">

--- a/src/web/tests/CareLeavers.Web.Tests/Controllers/ContentfulControllerTests.cs
+++ b/src/web/tests/CareLeavers.Web.Tests/Controllers/ContentfulControllerTests.cs
@@ -2,6 +2,7 @@ using CareLeavers.Web.Contentful;
 using CareLeavers.Web.Controllers;
 using CareLeavers.Web.Translation;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Hosting;
 using NSubstitute;
 
 namespace CareLeavers.Web.Tests.Controllers;
@@ -13,8 +14,9 @@ public class ContentfulControllerTests
     {
         var contentService = Substitute.For<IContentService>();
         var translationService = Substitute.For<ITranslationService>();
+        var environment = Substitute.For<IHostEnvironment>();
         
-        var controller = new ContentfulController(contentService, translationService);
+        var controller = new ContentfulController(contentService, translationService, environment);
         
         var result = await controller.Homepage(new MockContentfulConfiguration());
         


### PR DESCRIPTION
Fixes the following:
- Clears cache better on deployment
- Splits "Share Links" and "Show Print Button" per page
- **Breaking** - Turns on Print and Sharing for all pages - will need turning off on a few
- Fixes print styling of links
- Adds a new clear cache function
- Renders PDFs in browser to allow the user to download or print from there