### PR TITLE
PDF Translation Fix

### DIFF
--- a/.github/workflows/deploy-env.yaml
+++ b/.github/workflows/deploy-env.yaml
@@ -108,11 +108,13 @@ jobs:
           TF_VAR_caching_type: ${{ vars.CACHING_TYPE }}
           TF_VAR_scripts_clarity: ${{ vars.SCRIPTS_CLARITY }}
           TF_VAR_custom_domain: ${{ vars.CUSTOM_DOMAIN }}
+          TF_VAR_azure_translation_document_endpoint: ${{ vars.AZURE_TRANSLATION_DOCUMENT_ENDPOINT }}
           TF_VAR_azure_translation_access_key: ${{ secrets.AZURE_TRANSLATION_ACCESS_KEY }}
           TF_VAR_aspnetcore_environment: ${{ github.event.inputs.environment }}
           TF_VAR_azure_frontdoor_scale: ${{ vars.AZURE_FRONTDOOR_SCALE }}
           TF_VAR_pdf_generation_api_key: ${{ secrets.PDF_GENERATION_API_KEY }}
           TF_VAR_pdf_generation_use_sandbox: ${{ vars.PDF_GENERATION_USE_SANDBOX }}
+        
 
       - name: 'Terraform Apply'
         id: terraform_apply

--- a/src/infrastructure/terraform/variables.tf
+++ b/src/infrastructure/terraform/variables.tf
@@ -82,6 +82,12 @@ variable "azure_translation_access_key" {
   default     = ""
 }
 
+variable "azure_translation_document_endpoint" {
+  description = "Azure Document Translation Endpoint"
+  type        = string
+  default     = ""
+}
+
 variable "azure_frontdoor_scale" {
   description = "Azure Front Door Scale"
   type        = string

--- a/src/infrastructure/terraform/web.tf
+++ b/src/infrastructure/terraform/web.tf
@@ -11,6 +11,7 @@ locals {
     "Caching__Type"                         = var.caching_type
     "Caching__ConnectionString"             = lower(var.caching_type) == "redis" ? "@Microsoft.KeyVault(SecretUri=${azurerm_key_vault_secret.redis-cache-connection-string[0].versionless_id})" : ""
     "Scripts__Clarity"                      = var.scripts_clarity
+    "AzureTranslation__DocumentEndpoint"    = var.azure_translation_document_endpoint
     "AzureTranslation__AccessKey"           = "@Microsoft.KeyVault(SecretUri=${azurerm_key_vault_secret.azure-translation-access-key.versionless_id})"
     "PdfGeneration__ApiKey"                 = "@Microsoft.KeyVault(SecretUri=${azurerm_key_vault_secret.pdf-generation-api-key.versionless_id})"
     "PdfGeneration__Sandbox"                = var.pdf_generation_use_sandbox

--- a/src/web/CareLeavers.Web/CareLeavers.Web.csproj
+++ b/src/web/CareLeavers.Web/CareLeavers.Web.csproj
@@ -16,6 +16,7 @@
     </ItemGroup>
 
     <ItemGroup>
+        <PackageReference Include="Azure.AI.Translation.Document" Version="2.0.0" />
         <PackageReference Include="Azure.AI.Translation.Text" Version="1.0.0" />
         <PackageReference Include="Azure.Core" Version="1.45.0" />
         <PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.2.0" />

--- a/src/web/CareLeavers.Web/Translation/AzureTranslationOptions.cs
+++ b/src/web/CareLeavers.Web/Translation/AzureTranslationOptions.cs
@@ -8,5 +8,7 @@ public class AzureTranslationOptions
     
     public string Endpoint { get; set; } = string.Empty;
     
+    public string DocumentEndpoint { get; set; } = string.Empty;
+    
     public string Region { get; set; } = string.Empty;
 }

--- a/src/web/CareLeavers.Web/Translation/AzureTranslationService.cs
+++ b/src/web/CareLeavers.Web/Translation/AzureTranslationService.cs
@@ -1,4 +1,6 @@
+using System.Text;
 using Azure;
+using Azure.AI.Translation.Document;
 using Azure.AI.Translation.Text;
 using CareLeavers.Web.Configuration;
 using Microsoft.Extensions.Options;
@@ -17,6 +19,11 @@ public class AzureTranslationService(
         new Uri(options.Value.Endpoint),
         options.Value.Region);
 
+    private readonly SingleDocumentTranslationClient _documentTranslationClient = new(
+        new Uri(options.Value.DocumentEndpoint),
+        new AzureKeyCredential(options.Value.AccessKey)
+    );
+    
     public async Task<string?> TranslateHtml(string html, string toLanguage)
     {
         var language = await GetLanguage(toLanguage);
@@ -24,6 +31,11 @@ public class AzureTranslationService(
         if (language.Code == "en")
         {
             return html;
+        }
+
+        if (html.Length >= 50000)
+        {
+            return await TranslateDocument(html, language.Code);
         }
         
         var translateOptions = new TextTranslationTranslateOptions(toLanguage, html)
@@ -34,6 +46,23 @@ public class AzureTranslationService(
         var response = await _azureTranslationClient.TranslateAsync(translateOptions);
 
         return response.Value.FirstOrDefault()?.Translations.FirstOrDefault()?.Text;
+    }
+
+    private async Task<string?> TranslateDocument(string html, string language)
+    {
+        using var stream = new MemoryStream();
+        var writer = new StreamWriter(stream);
+        await writer.WriteAsync(html);
+        await writer.FlushAsync();
+        stream.Position = 0;
+
+        var sourceDocument = new MultipartFormFileData("source.html", stream, "text/html");
+        var content = new DocumentTranslateContent(sourceDocument);
+
+        var response = await _documentTranslationClient.TranslateAsync(language, content).ConfigureAwait(false);
+
+        var responseString = Encoding.UTF8.GetString(response.Value.ToArray());
+        return responseString;
     }
 
     public async Task<TranslationLanguage> GetLanguage(string code)

--- a/src/web/CareLeavers.Web/appsettings.json
+++ b/src/web/CareLeavers.Web/appsettings.json
@@ -36,6 +36,7 @@
   },
   "AzureTranslation": {
     "Endpoint": "https://api.cognitive.microsofttranslator.com/",
+    "DocumentEndpoint": "",
     "AccessKey": "",
     "Region": "westeurope"
   },

--- a/src/web/CareLeavers.Web/packages.lock.json
+++ b/src/web/CareLeavers.Web/packages.lock.json
@@ -2,6 +2,16 @@
   "version": 1,
   "dependencies": {
     "net8.0": {
+      "Azure.AI.Translation.Document": {
+        "type": "Direct",
+        "requested": "[2.0.0, )",
+        "resolved": "2.0.0",
+        "contentHash": "zNqMq7eEDvpavqUTG2O1dw+aVx+00LgDA76u/mc+aHF+XdM/lA3zWhNEnCo7aKXA3BluLsr37ZYzeaIrDixuPA==",
+        "dependencies": {
+          "Azure.Core": "1.44.1",
+          "System.Text.Json": "6.0.10"
+        }
+      },
       "Azure.AI.Translation.Text": {
         "type": "Direct",
         "requested": "[1.0.0, )",

--- a/src/web/tests/CareLeavers.Integration.Tests/packages.lock.json
+++ b/src/web/tests/CareLeavers.Integration.Tests/packages.lock.json
@@ -66,6 +66,15 @@
           "Microsoft.Testing.Platform.MSBuild": "1.5.3"
         }
       },
+      "Azure.AI.Translation.Document": {
+        "type": "Transitive",
+        "resolved": "2.0.0",
+        "contentHash": "zNqMq7eEDvpavqUTG2O1dw+aVx+00LgDA76u/mc+aHF+XdM/lA3zWhNEnCo7aKXA3BluLsr37ZYzeaIrDixuPA==",
+        "dependencies": {
+          "Azure.Core": "1.44.1",
+          "System.Text.Json": "6.0.10"
+        }
+      },
       "Azure.AI.Translation.Text": {
         "type": "Transitive",
         "resolved": "1.0.0",
@@ -2366,6 +2375,7 @@
       "careleavers.web": {
         "type": "Project",
         "dependencies": {
+          "Azure.AI.Translation.Document": "[2.0.0, )",
           "Azure.AI.Translation.Text": "[1.0.0, )",
           "Azure.Core": "[1.45.0, )",
           "Azure.Monitor.OpenTelemetry.AspNetCore": "[1.2.0, )",


### PR DESCRIPTION
**Reason**
Large HTML documents (> 50,000 characters) are not supported by the text translation service

**Fix**
- Updated to use the Document Translation service for larger HTML documents