### PR TITLE
Update CSP, Cookies, and Riddle

### DIFF
--- a/src/web/CareLeavers.Web/Views/Shared/Riddle.cshtml
+++ b/src/web/CareLeavers.Web/Views/Shared/Riddle.cshtml
@@ -1,12 +1,14 @@
 @model CareLeavers.Web.Models.Content.Riddle
 
 <div class="riddle2-wrapper"
-     data-rid-id="@Model.RiddleId"
-     data-auto-scroll="true"
+     data-rid-id="Model.RiddleId"
+     data-auto-scroll="false"
      data-is-fixed-height-enabled="false"
      data-bg="#fff"
      data-fg="#00205b"
-     data-embed-url="https://www.riddle.com/embed/a/@Model.RiddleId?lazyImages=false&staticHeight=false">
+     style="margin:0 auto; max-width:100%; width:100%;">
     <script src="https://www.riddle.com/embed/build-embedjs/embedV2.js" asp-add-nonce="true"></script>
-    <iframe title="@Model.Title" allow="autoplay" referrerpolicy="strict-origin"></iframe>
+    <iframe title="@Model.Title" 
+            src="https://www.riddle.com/embed/a/@Model.RiddleId?lazyImages=false&staticHeight=false" 
+            allow="autoplay" referrerpolicy="strict-origin"></iframe>
 </div>

--- a/src/web/CareLeavers.Web/Views/Shared/_CookieConsentPartial.cshtml
+++ b/src/web/CareLeavers.Web/Views/Shared/_CookieConsentPartial.cshtml
@@ -14,8 +14,8 @@
     var scriptConfig = ScriptOptions.Value;
     
     var consentCookie = Context.Request.Cookies[ops.ConsentCookie.Name!];
-    
-    var showBanner = consentCookie == null;
+
+    var showBanner = consentCookie == null && !Context.Request.Headers.Referer.Any(x => x != null && x.ToLower().Contains("riddle.com"));
     var acceptCookieString = consentFeature?.CreateConsentCookie() ?? string.Empty;
     var rejectCookieString = acceptCookieString.Replace(ops.ConsentCookieValue, "no");
     

--- a/src/web/CareLeavers.Web/appsettings.json
+++ b/src/web/CareLeavers.Web/appsettings.json
@@ -84,7 +84,7 @@
     ],
     "AllowHashes": [
       "sha256-xrAXrOY+vbRBqDmgZaRaAkCXcYa6i7XrdPSlOPQiY2E=",
-      "sha256-3qhhfkh2UpoqKUJs8ZDJg7cyT9OZB06hOGHhDPVJua0="
+      "sha256-EHM+nPamQPBwYVIwtgQKUmGfjqij8qTZMegp1TOVicU="
     ],
     "ReportOnly": false
   }


### PR DESCRIPTION
Added the following fixes:
- Stop cookie consent banner appearing on redirect from Riddle (fixes https://dfedigital.atlassian.net/browse/CARE-1043) due to cookie missing on the redirect
- Updated Riddle to stop auto-scroll
- Updated CSP to correct hash for custom GTM code