### PR TITLE
chore(CL-68): Removing reference to AI translation in workflow

### DIFF
--- a/.github/workflows/deploy-env.yaml
+++ b/.github/workflows/deploy-env.yaml
@@ -200,8 +200,6 @@ jobs:
           TF_VAR_caching_type: ${{ vars.CACHING_TYPE }}
           TF_VAR_scripts_clarity: ${{ vars.SCRIPTS_CLARITY }}
           TF_VAR_custom_domain: ${{ vars.CUSTOM_DOMAIN }}
-          TF_VAR_azure_translation_document_endpoint: ${{ vars.AZURE_TRANSLATION_DOCUMENT_ENDPOINT }}
-          TF_VAR_azure_translation_access_key: ${{ secrets.AZURE_TRANSLATION_ACCESS_KEY }}
           TF_VAR_azure_frontdoor_scale: ${{ vars.AZURE_FRONTDOOR_SCALE }}
           TF_VAR_pdf_generation_api_key: ${{ secrets.PDF_GENERATION_API_KEY }}
           TF_VAR_pdf_generation_use_sandbox: ${{ vars.PDF_GENERATION_USE_SANDBOX }}


### PR DESCRIPTION
Following the addition of the AI translate feature within terraform, terraform outputs are used to extract details from the AI translation resource. Removing reference in the workflow to the unused environment variables and secrets for this resource.