### PR TITLE
ci: Fix Directories for NPM Scan

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -43,8 +43,8 @@ updates:
   
   - package-ecosystem: npm
     directories:
-      - "/src/CareLeavers.E2ETests"
-      - "/src/pa11y"
+      - "/src/e2e/CareLeavers.E2ETests"
+      - "/src/e2e/pa11y"
       - "/src/utilities"
       - "/src/web/CareLeavers.Web"
       - "/src/contentful/Synchronisation"


### PR DESCRIPTION
Noticed Pa11y and the E2E tests weren't showing up in the NPM Dependabot PRs, accidentally missed the e2e folder when adding them originally, whoopsies!