### PR TITLE
refactor(CL-185): Pa11y Axe Runner

### DIFF
--- a/.github/workflows/validate-accessibility.yaml
+++ b/.github/workflows/validate-accessibility.yaml
@@ -12,24 +12,24 @@ on:
           - 'test'
           - 'staging'
           - 'www'
-jobs:
-  accessibility_scan:
-    name: 'Run Pa11y Accessibility Scan'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
 
-      - name: Set Node.js 20.x
+jobs:
+  accessibility-scan:
+    name: 'Run Pa11y Accessibility Scan'
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.ref }}
+
+      - name: Setup Node.JS
         uses: actions/setup-node@v6
         with:
-          node-version: 20.x
+          node-version: 'lts/Krypton'
 
-      - name: Run install
-        uses: borales/actions-yarn@v5
-        with:
-          cmd: install
-          dir: ./src/e2e/pa11y
-
-      - name: Run accessibility scans
+      - name: Run Accessibility Scan
         working-directory: ./src/e2e/pa11y
-        run: yarn pa11y-ci --config pa11y.json --sitemap https://${{ github.event.inputs.domain_prefix }}.support-for-care-leavers.education.gov.uk/sitemap.xml
+        run: |
+          yarn install --ignore-scripts --production=true
+          yarn pa11y-ci --config pa11y.json --sitemap https://${{ github.event.inputs.domain_prefix }}.support-for-care-leavers.education.gov.uk/sitemap.xml

--- a/.github/workflows/validate-accessibility.yaml
+++ b/.github/workflows/validate-accessibility.yaml
@@ -31,5 +31,5 @@ jobs:
       - name: Run Accessibility Scan
         working-directory: ./src/e2e/pa11y
         run: |
-          yarn install --ignore-scripts --production=true
+          yarn install --production=true
           yarn pa11y-ci --config pa11y.json --sitemap https://${{ github.event.inputs.domain_prefix }}.support-for-care-leavers.education.gov.uk/sitemap.xml

--- a/src/e2e/pa11y/pa11y.json
+++ b/src/e2e/pa11y/pa11y.json
@@ -1,6 +1,7 @@
 {
   "defaults": {
     "standard": "WCAG2AA",
+    "runners": ["axe"],
     "timeout": 10000,
     "userAgent": "pa11y - accessibility test (twitterbot)",
     "viewport": {

--- a/src/e2e/pa11y/package.json
+++ b/src/e2e/pa11y/package.json
@@ -2,6 +2,5 @@
   "dependencies": {
     "pa11y": "^9.1.1",
     "pa11y-ci": "^4.1.0"
-  },
-  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
+  }
 }


### PR DESCRIPTION
Ticket: [CL-185](https://dfedigital.atlassian.net/browse/CL-185)

This PR:

- Changes the Pa11y runner from HtmlCS (the default) to Axe
- Updates the workflow to clean it up a bit, mostly removing a third party action to install yarn - this isn't needed as GitHub runners have yarn pre-installed, so lowers our surface for supply chain attacks that little bit more

Note that now the tests fail because the site is failing to meet the Axe standards, but that's technically a separate issue to this ticket - https://github.com/DFE-Digital/care-leavers/actions/runs/24184183190/job/70584586238