### PR TITLE
refactor(CL-22): Contentful Webhooks

### DIFF
--- a/src/web/CareLeavers.Web/Contentful/Webhooks/Helpers/LinkedPageFinder.cs
+++ b/src/web/CareLeavers.Web/Contentful/Webhooks/Helpers/LinkedPageFinder.cs
@@ -1,0 +1,57 @@
+using CareLeavers.Web.Models.Content;
+using Contentful.Core;
+using Contentful.Core.Models;
+using Contentful.Core.Search;
+
+namespace CareLeavers.Web.Contentful.Webhooks.Helpers;
+
+public record LinkedPageResult(HashSet<string> ScannedIds, List<Page> Pages);
+
+public sealed class LinkedPageFinder(IContentfulClient contentfulClient, ILogger<LinkedPageFinder> logger)
+{
+    private readonly LinkedPageResult _result = new([], []);
+
+    public async Task<LinkedPageResult> FindPagesLinkedToEntry(string entryId)
+    {
+        _result.ScannedIds.Add(entryId);
+        await Search(entryId);
+        return _result;
+    }
+
+    public async Task<LinkedPageResult> FindPagesLinkedToAsset(string assetId)
+    {
+        foreach (ContentfulContent entry in await GetLinkedEntities(assetId, true)) await Search(entry.Sys.Id);
+        return _result;
+    }
+
+    private async Task Search(string entityId)
+    {
+        Stack<string> stack = new Stack<string>();
+        stack.Push(entityId);
+
+        while (stack.Count > 0)
+        {
+            ContentfulCollection<ContentfulContent> entries = await GetLinkedEntities(stack.Pop());
+
+            foreach (ContentfulContent entry in entries)
+            {
+                if (!_result.ScannedIds.Add(entry.Sys.Id)) continue;
+
+                if (entry is Page pageEntry) _result.Pages.Add(pageEntry);
+                else stack.Push(entry.Sys.Id);
+            }
+        }
+
+        logger.LogInformation("Scanned IDs: {Ids} | Pages: {Pages}", _result.ScannedIds.Count, _result.Pages.Count);
+    }
+
+    private async Task<ContentfulCollection<ContentfulContent>> GetLinkedEntities(string entityId, bool asset = false)
+    {
+        ContentfulCollection<ContentfulContent>? linkedToEntity = await contentfulClient.GetEntries(
+            asset
+                ? new QueryBuilder<ContentfulContent>().LinksToAsset(entityId).Include(0)
+                : new QueryBuilder<ContentfulContent>().LinksToEntry(entityId).Include(0));
+
+        return linkedToEntity ?? new ContentfulCollection<ContentfulContent> { Items = [] };
+    }
+}

--- a/src/web/CareLeavers.Web/Contentful/Webhooks/PublishAssetWebhook.cs
+++ b/src/web/CareLeavers.Web/Contentful/Webhooks/PublishAssetWebhook.cs
@@ -1,77 +1,28 @@
-using CareLeavers.Web.Models.Content;
-using Contentful.Core;
+using CareLeavers.Web.Contentful.Webhooks.Helpers;
 using Contentful.Core.Models;
-using Contentful.Core.Search;
 using ZiggyCreatures.Caching.Fusion;
 
 namespace CareLeavers.Web.Contentful.Webhooks;
 
-public class PublishAssetWebhook(
-    IContentfulClient contentfulClient,
+public sealed class PublishAssetWebhook(
     IFusionCache fusionCache,
+    LinkedPageFinder linkedPageFinder,
     ILogger<PublishAssetWebhook> logger)
 {
-    private HashSet<string> _idsScanned = [];
-    
     public async Task Consume(Asset asset)
     {
-        contentfulClient.ContentTypeResolver = new ContentfulEntityResolver();
+        logger.LogInformation("PublishAssetWebhook Started..");
 
-        // Get the IDs of the things linked to the asset
-        var linkedToAsset = await contentfulClient.GetEntries(new QueryBuilder<ContentfulContent>()
-            .LinksToAsset(asset.SystemProperties.Id)
-            .Include(0)
-        );
-        
-        // Clear our scanned IDs
-        _idsScanned.Clear();
-        var pageEntries = new List<Page>();
-        
-        // Loop through our entries linking to the asset and go deep
-        foreach (var entry in linkedToAsset.Items)
-        {
-            await FindLinkedPages(entry.Sys.Id, pageEntries);
-        }
-        
-        logger.LogInformation("The following slugs will be purged: {Slugs}", pageEntries.Select(x => x.Slug));
+        LinkedPageResult result = await linkedPageFinder.FindPagesLinkedToAsset(asset.SystemProperties.Id);
 
-        foreach (var pageEntry in pageEntries)
+        foreach (string slug in result.Pages.Select(p => p.Slug!))
         {
-            await fusionCache.RemoveAsync($"content:{pageEntry.Slug}");
-            if (pageEntry.Slug != null) await fusionCache.RemoveByTagAsync(pageEntry.Slug);
+            await fusionCache.RemoveAsync($"content:{slug}");
+            await fusionCache.RemoveByTagAsync(slug);
         }
+
+        foreach (string id in result.ScannedIds) await fusionCache.RemoveAsync(id);
         
-        // Now wipe all direct IDs that have been cached
-        foreach (var id in _idsScanned)
-        {
-            logger.LogInformation("Removing content item directly from cache with Id: {Id}", id);
-            await fusionCache.RemoveAsync(id);
-        }
+        logger.LogInformation("PublishAssetWebhook Finished!");
     }
-    
-    private async Task FindLinkedPages(string id, List<Page> linkedPages)
-    {
-        var entries = await contentfulClient.GetEntries(new QueryBuilder<ContentfulContent>()
-            .LinksToEntry(id)
-            .Include(0)
-        );
-
-        foreach (var linkedEntry in entries)
-        {
-            if (!_idsScanned.Add(linkedEntry.Sys.Id))
-            {
-                continue;
-            }
-            
-            if (linkedEntry is Page pageEntry)
-            {
-                linkedPages.Add(pageEntry);
-            }
-            else
-            {
-                await FindLinkedPages(linkedEntry.Sys.Id, linkedPages);
-            }
-        }
-    }
-
 }

--- a/src/web/CareLeavers.Web/Contentful/Webhooks/PublishContentfulWebhook.cs
+++ b/src/web/CareLeavers.Web/Contentful/Webhooks/PublishContentfulWebhook.cs
@@ -1,261 +1,185 @@
+using CareLeavers.Web.Contentful.Webhooks.Helpers;
 using CareLeavers.Web.Models.Content;
 using Contentful.Core;
+using Contentful.Core.Errors;
 using Contentful.Core.Models;
 using Contentful.Core.Search;
 using ZiggyCreatures.Caching.Fusion;
 
 namespace CareLeavers.Web.Contentful.Webhooks;
 
-public class PublishContentfulWebhook(
+public sealed class PublishContentfulWebhook(
     IContentfulClient contentfulClient,
     IFusionCache fusionCache,
     IContentfulManagementClient contentfulManagementClient,
+    LinkedPageFinder linkedPageFinder,
     ILogger<PublishContentfulWebhook> logger)
 {
-    private HashSet<string> _idsScanned = [];
-
-    private readonly List<string> _entryTypesForRepublishingLinkedPages =
+    private static readonly List<string> EntryTypesForRepublishingLinkedPages =
     [
         RichContent.ContentType,
         RichContentBlock.ContentType,
         PrintableCollection.ContentType
     ];
 
-    private readonly List<Page>? _linkedPageEntries = [];
-
     public async Task Consume(Entry<ContentfulContent> entry, string? topic)
     {
-        contentfulClient.ContentTypeResolver = new ContentfulEntityResolver();
+        logger.LogInformation("PublishContentfulWebhook Started..");
+        
+        LinkedPageResult linkedPages = await linkedPageFinder.FindPagesLinkedToEntry(entry.SystemProperties.Id);
 
-        // Reset our scanned list
-        _idsScanned.Clear();
-
-        // Add this entry, since we've already got it
-        _idsScanned.Add(entry.SystemProperties.Id);
-
-        if (entry.SystemProperties.ContentType.SystemProperties.Id == RedirectionRules.ContentType)
+        switch (entry.SystemProperties.ContentType.SystemProperties.Id)
         {
-            logger.LogInformation("Redirection rules entry updated, purging redirections cache");
-            try
-            {
-                await fusionCache.RemoveAsync("content:redirections");
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex, "Unable to clear redirection rules");
-            }
-        }
-        else if (entry.SystemProperties.ContentType.SystemProperties.Id == Page.ContentType)
-        {
-            var pageEntry = await contentfulClient.GetEntry<Page>(entry.SystemProperties.Id);
-
-            if (pageEntry == null)
-            {
-                return;
-            }
-
-            logger.LogInformation("The following slug will be purged: {Slug}", pageEntry.Slug);
-
-            try
-            {
-                await fusionCache.RemoveAsync($"content:{pageEntry.Slug}");
-                if (pageEntry.Slug != null)
-                    await fusionCache.RemoveByTagAsync(pageEntry.Slug);
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex, "Unable to purge page with slug {slug}", pageEntry.Slug);
-            }
-
-            var pageById = await fusionCache.TryGetAsync<Page>(pageEntry.Sys.Id);
-
-            if (pageById.HasValue && pageEntry.Slug != null && pageById.Value.Slug != pageEntry.Slug)
-            {
-                logger.LogInformation("Slug changed from {OldSlug} to {NewSlug}", pageById.Value.Slug, pageEntry.Slug);
-                await fusionCache.RemoveAsync($"content:{pageById.Value.Slug}");
-
-                if (pageById.Value.Slug != null)
-                    await fusionCache.RemoveByTagAsync(pageById.Value.Slug);
-
-                var redirectionContent = await contentfulClient.GetEntries(
-                    new QueryBuilder<RedirectionRules>()
-                        .ContentTypeIs(RedirectionRules.ContentType)
-                        .Include(1));
-
-                var redirectionRules = redirectionContent.Items.FirstOrDefault() ?? new RedirectionRules()
-                {
-                    Sys = new SystemProperties()
-                    {
-                        Id = "redirectionRulesId"
-                    }
-                };
-
-                if (pageById.Value.Slug != null)
-                {
-                    redirectionRules.Rules[pageById.Value.Slug] = pageEntry.Slug;
-                    redirectionRules.Rules.Remove(pageEntry.Slug);
-                }
-
-                var updatedEntryResp = await contentfulManagementClient.CreateOrUpdateEntry(new Entry<dynamic>
-                {
-                    SystemProperties = new SystemProperties()
-                    {
-                        Id = redirectionRules.Sys.Id,
-                        Version = redirectionRules.Sys.Version
-                    },
-                    Fields = new
-                    {
-                        title = new Dictionary<string, dynamic>
-                        {
-                            ["en-US"] = "Redirection Rules - DO NOT DELETE"
-                        },
-                        rules = new Dictionary<string, dynamic>
-                        {
-                            ["en-US"] = redirectionRules.Rules
-                        }
-                    }
-                }, contentTypeId: RedirectionRules.ContentType, version: redirectionRules.Sys.PublishedVersion + 1);
-
-                //Publish updated Redirection Rules
-                await contentfulManagementClient.PublishEntry(
-                    updatedEntryResp.SystemProperties.Id,
-                    updatedEntryResp.SystemProperties.Version ?? 1
-                );
-            }
-        }
-        else if (entry.SystemProperties.ContentType.SystemProperties.Id == ContentfulConfigurationEntity.ContentType)
-        {
-            logger.LogInformation("Configuration entry updated, purging configuration cache");
-            try
-            {
-                await fusionCache.RemoveAsync("content:configuration");
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex, "Unable to purge configuration");
-            }
-        }
-        else if (entry.SystemProperties.ContentType.SystemProperties.Id == PrintableCollection.ContentType)
-        {
-            var collection = await contentfulClient.GetEntry<PrintableCollection>(entry.SystemProperties.Id);
-            logger.LogInformation("The following collection will be purged: {identifier}", collection.Identifier);
-
-            try
-            {
-                await fusionCache.RemoveAsync($"collection:{collection.Identifier}");
-                await fusionCache.RemoveByTagAsync($"pc-{collection.Identifier}");
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex, "Unable to purge collection with identifier {identifier}", collection.Identifier);
-            }
-
-            await fusionCache.RemoveAsync(collection.Sys.Id);
-
-            await RepublishPagesLinkedToEntry(entry, topic);
-        }
-        else
-        {
-            await FindLinkedPages(entry.SystemProperties.Id, _linkedPageEntries);
-
-            if (_linkedPageEntries != null)
-            {
-                logger.LogInformation("The following slugs will be purged: {Slugs}",
-                    _linkedPageEntries.Select(x => x.Slug));
-
-                foreach (var pageEntry in _linkedPageEntries)
-                {
-                    try
-                    {
-                        await fusionCache.RemoveAsync($"content:{pageEntry.Slug}");
-
-                        if (pageEntry.Slug != null) await fusionCache.RemoveByTagAsync(pageEntry.Slug);
-                    }
-                    catch (Exception ex)
-                    {
-                        logger.LogError(ex, "Unable to purge page with slug {slug}", pageEntry.Slug);
-                    }
-                }
-            }
+            case RedirectionRules.ContentType:
+                await HandleRedirectionRulesType();
+                break;
+            case ContentfulConfigurationEntity.ContentType:
+                await HandleContentfulConfigurationType();
+                break;
+            case Page.ContentType:
+                await HandlePageType(entry);
+                break;
+            case PrintableCollection.ContentType:
+                await HandlePrintableCollectionType(entry);
+                break;
+            default:
+                await HandleOtherType(entry.SystemProperties.Id, linkedPages);
+                break;
         }
 
-        // Now wipe all direct IDs that have been cached
-        foreach (var id in _idsScanned)
+        foreach (string id in linkedPages.ScannedIds) await fusionCache.RemoveAsync(id);
+
+        await fusionCache.RemoveAsync("content:sitemap");
+        await fusionCache.RemoveAsync("content:hierarchy");
+
+        await RepublishPagesLinkedToEntry(topic, entry.SystemProperties.ContentType.SystemProperties.Id,
+            entry.SystemProperties.Id, linkedPages);
+
+        logger.LogInformation("PublishContentfulWebhook Finished!");
+    }
+
+    private async Task HandleRedirectionRulesType()
+    {
+        logger.LogInformation("Redirection Rules Entry Updated - Purging Cache..");
+        await fusionCache.RemoveAsync("content:redirections");
+    }
+
+    private async Task HandleContentfulConfigurationType()
+    {
+        logger.LogInformation("Configuration Entry Updated - Purging Cache..");
+        await fusionCache.RemoveAsync("content:configuration");
+    }
+
+    private async Task HandlePrintableCollectionType(Entry<ContentfulContent> entry)
+    {
+        logger.LogInformation("Printable Collection Entry Updated - Purging Cache..");
+
+        PrintableCollection collection =
+            await contentfulClient.GetEntry<PrintableCollection>(entry.SystemProperties.Id);
+
+        await fusionCache.RemoveAsync($"collection:{collection.Identifier}");
+        await fusionCache.RemoveByTagAsync($"pc-{collection.Identifier}");
+        await fusionCache.RemoveAsync(collection.Sys.Id);
+    }
+
+    private async Task HandlePageType(Entry<ContentfulContent> entry)
+    {
+        logger.LogInformation("Page Entry {Id} Updated - Purging Cache..", entry.SystemProperties.Id);
+
+        Page page = await contentfulClient.GetEntry<Page>(entry.SystemProperties.Id);
+        MaybeValue<Page> cachedOldPage = await fusionCache.TryGetAsync<Page>(page.Sys.Id);
+
+        await fusionCache.RemoveAsync($"content:{page.Slug}");
+        await fusionCache.RemoveByTagAsync(page.Slug!);
+
+        if (!cachedOldPage.HasValue) return;
+        if (cachedOldPage.Value.Slug!.Equals(page.Slug)) return;
+
+        await HandlePageTypeSlugChange(cachedOldPage.Value.Slug, page.Slug!);
+    }
+
+    private async Task HandlePageTypeSlugChange(string staleSlugInCache, string updatedSlug)
+    {
+        logger.LogInformation("Slug Changed From {OldSlug} to {NewSlug} - Purging Cache & Updating Redirection Rules..",
+            staleSlugInCache, updatedSlug);
+
+        await fusionCache.RemoveAsync($"content:{staleSlugInCache}");
+        await fusionCache.RemoveByTagAsync(staleSlugInCache);
+
+        RedirectionRules? redirectionRules =
+            (await contentfulClient.GetEntries(
+                new QueryBuilder<RedirectionRules>().ContentTypeIs(RedirectionRules.ContentType))).FirstOrDefault();
+
+        if (redirectionRules is not null)
         {
-            logger.LogInformation("Removing content item directly from cache with Id: {Id}", id);
-            try
-            {
-                await fusionCache.RemoveAsync(id);
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex, "Unable to purge entry with id {id}", id);
-            }
+            redirectionRules.Rules[staleSlugInCache] = updatedSlug;
+            redirectionRules.Rules.Remove(updatedSlug);
         }
+
+        Entry<dynamic> redirectionRulesUpdated = await contentfulManagementClient.CreateOrUpdateEntry(
+            UpdatedRedirectionRuleEntry(redirectionRules), contentTypeId: RedirectionRules.ContentType,
+            version: redirectionRules?.Sys.PublishedVersion + 1 ?? 1);
 
         try
         {
-            await fusionCache.RemoveAsync("content:sitemap");
-            await fusionCache.RemoveAsync("content:hierarchy");
+            await contentfulManagementClient.PublishEntry(redirectionRulesUpdated.SystemProperties.Id,
+                redirectionRulesUpdated.SystemProperties.Version ?? 1);
         }
-        catch (Exception ex)
+        catch (ContentfulException e)
         {
-            logger.LogError(ex, "Unable to clear sitemap and hierarchy");
+            logger.LogError(e, "Error Publishing Redirection Rules");
         }
-
-        await RepublishPagesLinkedToEntry(entry, topic);
     }
 
-    private async Task RepublishPagesLinkedToEntry(Entry<ContentfulContent> entry, string? topic)
+    private async Task HandleOtherType(string entryId, LinkedPageResult linkedPages)
     {
-        // Only republish if this is a publish event, and the entry type is in our list
-        if (topic == "ContentManagement.Entry.publish" &&
-            _entryTypesForRepublishingLinkedPages.Contains(entry.SystemProperties.ContentType.SystemProperties.Id))
+        logger.LogInformation("Other Entry {Id} Updated - Purging Cache..", entryId);
+
+        foreach (string slug in linkedPages.Pages.Select(p => p.Slug!))
         {
-            if (_linkedPageEntries?.Count == 0 || _linkedPageEntries == null)
-                await FindLinkedPages(entry.SystemProperties.Id, _linkedPageEntries);
+            await fusionCache.RemoveAsync($"content:{slug}");
+            await fusionCache.RemoveByTagAsync(slug);
+        }
+    }
 
-            if (_linkedPageEntries == null)
-                return;
+    private async Task RepublishPagesLinkedToEntry(string? topic, string contentType, string entryId,
+        LinkedPageResult linkedPages)
+    {
+        if (topic is not "ContentManagement.Entry.publish") return;
+        if (!EntryTypesForRepublishingLinkedPages.Contains(contentType)) return;
 
+        logger.LogInformation("Republishing Pages Linked to Entry {Id}", entryId);
+
+        foreach (Page page in linkedPages.Pages)
+        {
             try
             {
-                foreach (var page in _linkedPageEntries)
-                    await contentfulManagementClient.PublishEntry(page.Sys.Id, page.Sys.PublishedVersion + 1 ?? 1);
-
-                logger.LogInformation("The following pages were Republished: {Slugs}",
-                    _linkedPageEntries.Select(x => x.Slug));
+                await contentfulManagementClient.PublishEntry(page.Sys.Id, page.Sys.PublishedVersion + 1 ?? 1);
             }
-            catch (Exception ex)
+            catch (ContentfulException e)
             {
-                logger.LogError(ex, "Failed to republish linked pages: {LinkedPages}",
-                    _linkedPageEntries.Select(x => x.Slug));
+                logger.LogError(e, "Error Publishing Linked Page: {Slug}", page.Slug);
             }
         }
     }
 
-    private async Task FindLinkedPages(string id, List<Page>? linkedPages)
+    private static Entry<dynamic> UpdatedRedirectionRuleEntry(RedirectionRules? redirectionRules) => new()
     {
-        var entries = await contentfulClient.GetEntries(new QueryBuilder<ContentfulContent>()
-            .LinksToEntry(id)
-            .Include(0)
-        );
-
-        foreach (var linkedEntry in entries)
+        SystemProperties = new SystemProperties
         {
-            if (!_idsScanned.Add(linkedEntry.Sys.Id))
+            Id = redirectionRules?.Sys.Id ?? "redirectionRulesId",
+            Version = redirectionRules?.Sys.Version
+        },
+        Fields = new
+        {
+            title = new Dictionary<string, dynamic>
             {
-                continue;
-            }
-
-            if (linkedEntry is Page pageEntry)
+                ["en-US"] = redirectionRules?.Title ?? "Redirection Rules - DO NOT DELETE"
+            },
+            rules = new Dictionary<string, dynamic>
             {
-                linkedPages?.Add(pageEntry);
-            }
-            else
-            {
-                await FindLinkedPages(linkedEntry.Sys.Id, linkedPages);
+                ["en-US"] = redirectionRules?.Rules ?? []
             }
         }
-    }
+    };
 }

--- a/src/web/CareLeavers.Web/Contentful/Webhooks/README.md
+++ b/src/web/CareLeavers.Web/Contentful/Webhooks/README.md
@@ -1,0 +1,45 @@
+# Contentful Webhooks
+
+This folder contains handlers for webhooks that fire off from Contentful, each of them handling a different event type.
+
+### PublishAssetWebhook
+
+Handles the "Asset" event type, which is triggered when an Asset is created, modified or deleted in Contentful. These are things such as images or video.
+
+The purpose of this handler is to clear the cache of any pages that use the asset that was modified, so that on the next page load the updated entry is fetched instead of using the now stale cached version.
+
+### PublishContentfulWebhook
+
+Handles the "Entry" event type, which is triggered when an Entry is created, modified or deleted in Contentful. These are things such as Pages, Banners, and other Content types.
+
+The primary purpose of this handler is to clear caches depending on the type of Content that was modified, so that the latest version of it can be fetched instead of using the stale cached version.
+
+At the end it will also republish anything that was linked to the content that was modified, as they would otherwise be in a "Changed" state on the CMS.
+
+Specifically what happens to each type:
+
+#### Redirection Rules
+
+If this has been modified (by the page slug changing or a manual change on the CMS) then the cache for the redirection rules is cleared.
+
+#### Configuration
+
+If the Contentful Configuration Entity is modified, then the cache for the configuration is cleared.
+
+#### Page
+
+If a page is changed a few things happen:
+
+- The page is cleared from the cache
+- At the same time, the slug for the page that was stored in the cache is compared to the slug of the updated page
+- If the slugs don't match, the redirection rules are updated to redirect the old slug to the new slug
+- The old slug references are removed from the cache for good measure
+- If the redirection rules were changed, it is republished on Contentful
+
+#### Printable Collection
+
+If a printable collection is changed, it's cleared from the cache.
+
+#### Other..
+
+Any other types are always embedded within a Page, so similarly to the Asset clearing this will handle clearing the cache of all pages that use the updated Content, so the latest version can be fetched from the CMS.

--- a/src/web/CareLeavers.Web/Models/Content/ContentfulConfigurationEntity.cs
+++ b/src/web/CareLeavers.Web/Models/Content/ContentfulConfigurationEntity.cs
@@ -11,8 +11,7 @@ public class ContentfulConfigurationEntity : ContentfulContent
         Live
     }
     
-    public static string ContentType { get; } = "configuration";
-
+    public const string ContentType = "configuration";
     
     public string ServiceName { get; set; } = string.Empty;
 

--- a/src/web/CareLeavers.Web/Models/Content/Page.cs
+++ b/src/web/CareLeavers.Web/Models/Content/Page.cs
@@ -5,7 +5,7 @@ namespace CareLeavers.Web.Models.Content;
 
 public class Page : ContentfulContent
 {
-    public static string ContentType { get; } = "page";
+    public const string ContentType = "page";
     
     public Page? Parent { get; set; }
     

--- a/src/web/CareLeavers.Web/Models/Content/PrintableCollection.cs
+++ b/src/web/CareLeavers.Web/Models/Content/PrintableCollection.cs
@@ -5,7 +5,7 @@ namespace CareLeavers.Web.Models.Content;
 public class PrintableCollection : ContentfulContent
 {
     
-    public static string ContentType { get; } = "printableCollection";
+    public const string ContentType = "printableCollection";
 
     public required string Title { get; set; }
     

--- a/src/web/CareLeavers.Web/Models/Content/RedirectionRules.cs
+++ b/src/web/CareLeavers.Web/Models/Content/RedirectionRules.cs
@@ -2,7 +2,7 @@ namespace CareLeavers.Web.Models.Content;
 
 public class RedirectionRules : ContentfulContent
 {
-    public static string ContentType { get; } = "redirectionRules";
+    public const string ContentType = "redirectionRules";
 
     public string Title { get; set; } = string.Empty;
     

--- a/src/web/CareLeavers.Web/Program.cs
+++ b/src/web/CareLeavers.Web/Program.cs
@@ -8,6 +8,7 @@ using CareLeavers.Web;
 using CareLeavers.Web.Configuration;
 using CareLeavers.Web.Contentful;
 using CareLeavers.Web.Contentful.Webhooks;
+using CareLeavers.Web.Contentful.Webhooks.Helpers;
 using CareLeavers.Web.ContentfulRenderers;
 using CareLeavers.Web.Controllers;
 using CareLeavers.Web.GetToAnAnswerRun;
@@ -431,6 +432,8 @@ try
     contentfulClient.SerializerSettings.MaxDepth = 128;
     contentfulClient.Serializer.MaxDepth = 128;
 
+    contentfulClient.ContentTypeResolver = new ContentfulEntityResolver();
+
     Constants.Serializer = contentfulClient.Serializer;
     Constants.SerializerSettings = contentfulClient.SerializerSettings;
 
@@ -438,13 +441,14 @@ try
     {
         consumers.AddConsumer<Entry<ContentfulContent>>("*", "Entry", "*", async (entry, httpContext) =>
         {
-            var topic = httpContext.Request.Headers["X-Contentful-Topic"].FirstOrDefault();
+            string? topic = httpContext.Request.Headers["X-Contentful-Topic"].FirstOrDefault();
             
-            var webhookConsumer = new PublishContentfulWebhook(
-                app.Services.GetRequiredService<IContentfulClient>(),
-                app.Services.GetRequiredService<IFusionCache>(),
-                app.Services.GetRequiredService<IContentfulManagementClient>(),
-                app.Services.GetRequiredService<ILogger<PublishContentfulWebhook>>());
+            PublishContentfulWebhook webhookConsumer = 
+                new(contentfulClient, 
+                    app.Services.GetRequiredService<IFusionCache>(), 
+                    app.Services.GetRequiredService<IContentfulManagementClient>(), 
+                    new LinkedPageFinder(contentfulClient, app.Services.GetRequiredService<ILogger<LinkedPageFinder>>()), 
+                    app.Services.GetRequiredService<ILogger<PublishContentfulWebhook>>());
 
             await webhookConsumer.Consume(entry, topic);
             
@@ -453,10 +457,11 @@ try
 
         consumers.AddConsumer<Asset>("*", "Asset", "*", async asset =>
         {
-            var webhookConsumer = new PublishAssetWebhook(
-                app.Services.GetRequiredService<IContentfulClient>(),
-                app.Services.GetRequiredService<IFusionCache>(),
-                app.Services.GetRequiredService<ILogger<PublishAssetWebhook>>());
+            PublishAssetWebhook webhookConsumer = 
+                new(app.Services.GetRequiredService<IFusionCache>(), 
+                    new LinkedPageFinder(contentfulClient, 
+                        app.Services.GetRequiredService<ILogger<LinkedPageFinder>>()), 
+                    app.Services.GetRequiredService<ILogger<PublishAssetWebhook>>());
 
             await webhookConsumer.Consume(asset);
 

--- a/src/web/tests/CareLeavers.Web.Tests/Contentful/Webhooks/PublishAssetWebhookTests.cs
+++ b/src/web/tests/CareLeavers.Web.Tests/Contentful/Webhooks/PublishAssetWebhookTests.cs
@@ -1,4 +1,5 @@
 using CareLeavers.Web.Contentful.Webhooks;
+using CareLeavers.Web.Contentful.Webhooks.Helpers;
 using CareLeavers.Web.Models.Content;
 using Contentful.Core;
 using Contentful.Core.Models;
@@ -22,7 +23,8 @@ public class PublishAssetWebhookTests
         _contentfulClient = Substitute.For<IContentfulClient>();
         _fusionCache = Substitute.For<IFusionCache>();
 
-        _publishAssetWebhook = new PublishAssetWebhook(_contentfulClient, _fusionCache,
+        _publishAssetWebhook = new PublishAssetWebhook(_fusionCache,
+            new LinkedPageFinder(_contentfulClient, Substitute.For<ILogger<LinkedPageFinder>>()),
             Substitute.For<ILogger<PublishAssetWebhook>>());
     }
 
@@ -82,19 +84,20 @@ public class PublishAssetWebhookTests
             .GetEntries(
                 Arg.Is<QueryBuilder<ContentfulContent>>(qB => qB.Build() == $"?links_to_asset={assetId}&include=0"))
             .Returns(Task.FromResult(assetLinkedContent));
-        
+
         _contentfulClient
             .GetEntries(
-                Arg.Is<QueryBuilder<ContentfulContent>>(qB => qB.Build() == $"?links_to_entry={richContentId}&include=0"))
+                Arg.Is<QueryBuilder<ContentfulContent>>(qB =>
+                    qB.Build() == $"?links_to_entry={richContentId}&include=0"))
             .Returns(Task.FromResult(pageLinkedContent));
-        
+
         _contentfulClient
             .GetEntries(
                 Arg.Is<QueryBuilder<ContentfulContent>>(qB => qB.Build() == $"?links_to_entry={pageId}&include=0"))
-            .Returns(Task.FromResult(new ContentfulCollection<ContentfulContent>()));
+            .Returns(Task.FromResult(new ContentfulCollection<ContentfulContent> { Items = [] }));
 
         await _publishAssetWebhook.Consume(asset);
-        
+
         await _fusionCache.Received(1).RemoveAsync(pageId);
         await _fusionCache.Received(1).RemoveAsync($"content:{pageSlug}");
     }
@@ -109,13 +112,17 @@ public class PublishAssetWebhookTests
         const string pageSlug = "page-one-slug";
 
         Asset asset = new Asset { SystemProperties = new SystemProperties { Id = assetId } };
-        RichContentBlock richContentBlockOne = new RichContentBlock { Sys = new SystemProperties { Id = richContentIdOne } };
-        RichContentBlock richContentBlockTwo = new RichContentBlock { Sys = new SystemProperties { Id = richContentIdTwo } };
+        RichContentBlock richContentBlockOne = new RichContentBlock
+            { Sys = new SystemProperties { Id = richContentIdOne } };
+        RichContentBlock richContentBlockTwo = new RichContentBlock
+            { Sys = new SystemProperties { Id = richContentIdTwo } };
         Page page = new Page { Sys = new SystemProperties { Id = pageId }, Slug = pageSlug };
 
         ContentfulCollection<ContentfulContent> assetLinkedContent = new() { Items = [richContentBlockOne] };
-        ContentfulCollection<ContentfulContent> richContentBlockOneLinkedContent = new() { Items = [richContentBlockTwo, page] };
-        ContentfulCollection<ContentfulContent> richContentBlockTwoLinkedContent = new() { Items = [richContentBlockOne] };
+        ContentfulCollection<ContentfulContent> richContentBlockOneLinkedContent =
+            new() { Items = [richContentBlockTwo, page] };
+        ContentfulCollection<ContentfulContent> richContentBlockTwoLinkedContent =
+            new() { Items = [richContentBlockOne] };
 
         _contentfulClient
             .GetEntries(
@@ -124,18 +131,20 @@ public class PublishAssetWebhookTests
 
         _contentfulClient
             .GetEntries(
-                Arg.Is<QueryBuilder<ContentfulContent>>(qB => qB.Build() == $"?links_to_entry={richContentIdOne}&include=0"))
+                Arg.Is<QueryBuilder<ContentfulContent>>(qB =>
+                    qB.Build() == $"?links_to_entry={richContentIdOne}&include=0"))
             .Returns(Task.FromResult(richContentBlockOneLinkedContent));
 
         _contentfulClient
             .GetEntries(
-                Arg.Is<QueryBuilder<ContentfulContent>>(qB => qB.Build() == $"?links_to_entry={richContentIdTwo}&include=0"))
+                Arg.Is<QueryBuilder<ContentfulContent>>(qB =>
+                    qB.Build() == $"?links_to_entry={richContentIdTwo}&include=0"))
             .Returns(Task.FromResult(richContentBlockTwoLinkedContent));
-        
+
         _contentfulClient
             .GetEntries(
                 Arg.Is<QueryBuilder<ContentfulContent>>(qB => qB.Build() == $"?links_to_entry={pageId}&include=0"))
-            .Returns(Task.FromResult(new ContentfulCollection<ContentfulContent>()));
+            .Returns(Task.FromResult(new ContentfulCollection<ContentfulContent> { Items = [] }));
 
         await _publishAssetWebhook.Consume(asset);
 

--- a/src/web/tests/CareLeavers.Web.Tests/Contentful/Webhooks/PublishContentfulWebhookTests.cs
+++ b/src/web/tests/CareLeavers.Web.Tests/Contentful/Webhooks/PublishContentfulWebhookTests.cs
@@ -1,4 +1,5 @@
 using CareLeavers.Web.Contentful.Webhooks;
+using CareLeavers.Web.Contentful.Webhooks.Helpers;
 using CareLeavers.Web.Models.Content;
 using Contentful.Core;
 using Contentful.Core.Models;
@@ -25,7 +26,9 @@ public class PublishContentfulWebhookTests
         _contentfulManagementClient = Substitute.For<IContentfulManagementClient>();
 
         _publishContentfulWebhook = new PublishContentfulWebhook(_contentfulClient, _fusionCache,
-            _contentfulManagementClient, Substitute.For<ILogger<PublishContentfulWebhook>>());
+            _contentfulManagementClient,
+            new LinkedPageFinder(_contentfulClient, Substitute.For<ILogger<LinkedPageFinder>>()),
+            Substitute.For<ILogger<PublishContentfulWebhook>>());
     }
 
     [Test]

--- a/src/web/tests/CareLeavers.Web.Tests/Contentful/Webhooks/PublishContentfulWebhookTests.cs
+++ b/src/web/tests/CareLeavers.Web.Tests/Contentful/Webhooks/PublishContentfulWebhookTests.cs
@@ -2,6 +2,7 @@ using CareLeavers.Web.Contentful.Webhooks;
 using CareLeavers.Web.Contentful.Webhooks.Helpers;
 using CareLeavers.Web.Models.Content;
 using Contentful.Core;
+using Contentful.Core.Errors;
 using Contentful.Core.Models;
 using Contentful.Core.Search;
 using Microsoft.Extensions.Logging;
@@ -15,6 +16,7 @@ public class PublishContentfulWebhookTests
     private IContentfulClient _contentfulClient;
     private IFusionCache _fusionCache;
     private IContentfulManagementClient _contentfulManagementClient;
+    private ILogger<PublishContentfulWebhook> _logger;
 
     private PublishContentfulWebhook _publishContentfulWebhook;
 
@@ -24,11 +26,12 @@ public class PublishContentfulWebhookTests
         _contentfulClient = Substitute.For<IContentfulClient>();
         _fusionCache = Substitute.For<IFusionCache>();
         _contentfulManagementClient = Substitute.For<IContentfulManagementClient>();
+        _logger = Substitute.For<ILogger<PublishContentfulWebhook>>();
 
         _publishContentfulWebhook = new PublishContentfulWebhook(_contentfulClient, _fusionCache,
             _contentfulManagementClient,
             new LinkedPageFinder(_contentfulClient, Substitute.For<ILogger<LinkedPageFinder>>()),
-            Substitute.For<ILogger<PublishContentfulWebhook>>());
+            _logger);
     }
 
     [Test]
@@ -182,6 +185,79 @@ public class PublishContentfulWebhookTests
 
         await _contentfulManagementClient.Received(1).PublishEntry(pageId, 2);
         await AssertDefaultCacheClears(entryId, pageId);
+    }
+
+    [Test]
+    public async Task Consume_WhenPageSlugChanged_And_PublishingRedirectionRulesFails_LogsError()
+    {
+        const string entryId = "EntryId";
+        const string pageSlug = "page-slug";
+        const string oldPageSlug = "old-page-slug";
+        const string redirectionRulesId = "RedirectionRulesId";
+        Entry<ContentfulContent> entry = CreateEntry(Page.ContentType, entryId);
+
+        RedirectionRules redirectionRules = new RedirectionRules
+        {
+            Sys = new SystemProperties { Id = redirectionRulesId, Version = 1, PublishedVersion = 1 },
+            Rules = []
+        };
+
+        Entry<dynamic> updatedEntryResponse = new()
+        {
+            SystemProperties = new SystemProperties { Id = redirectionRulesId, Version = 2 }
+        };
+
+        Page pageFromContentful = new Page { Sys = new SystemProperties { Id = entryId }, Slug = pageSlug };
+        Page outdatedPageInCache = new Page { Sys = new SystemProperties { Id = entryId }, Slug = oldPageSlug };
+
+        _contentfulClient.GetEntry<Page>(entryId).Returns(Task.FromResult(pageFromContentful));
+        _fusionCache.TryGetAsync<Page>(entryId).Returns(MaybeValue<Page>.FromValue(outdatedPageInCache));
+        _contentfulClient.GetEntries(Arg.Any<QueryBuilder<RedirectionRules>>()).Returns(
+            new ContentfulCollection<RedirectionRules>
+            {
+                Items = [redirectionRules]
+            });
+        _contentfulManagementClient.CreateOrUpdateEntry(Arg.Any<Entry<dynamic>>(), contentTypeId: Arg.Any<string>(),
+                version: Arg.Any<int?>())
+            .ReturnsForAnyArgs(updatedEntryResponse);
+
+        _contentfulManagementClient.PublishEntry(redirectionRulesId, 2)
+            .Returns(Task.FromException<Entry<dynamic>>(new ContentfulException(500, "Error")));
+
+        await _publishContentfulWebhook.Consume(entry, "Topic");
+
+        _logger.Received(1).Log(
+            LogLevel.Error,
+            Arg.Any<EventId>(),
+            Arg.Is<object>(v => v.ToString()!.Contains("Error Publishing Redirection Rules")),
+            Arg.Is<ContentfulException>(e => e.Message == "Error"),
+            Arg.Any<Func<object, Exception?, string>>());
+    }
+
+    [Test]
+    public async Task Consume_WhenRepublishingLinkedPagesFails_LogsError()
+    {
+        const string entryId = "EntryId";
+        const string pageId = "PageId";
+        const string pageSlug = "page-slug";
+        Entry<ContentfulContent> entry = CreateEntry(RichContent.ContentType, entryId);
+        Page linkedPage = new Page
+            { Sys = new SystemProperties { Id = pageId, PublishedVersion = 1 }, Slug = pageSlug };
+
+        _contentfulClient.GetEntries(Arg.Any<QueryBuilder<ContentfulContent>>())
+            .Returns(new ContentfulCollection<ContentfulContent> { Items = [linkedPage] });
+
+        _contentfulManagementClient.PublishEntry(pageId, 2)
+            .Returns(Task.FromException<Entry<dynamic>>(new ContentfulException(500, "Error")));
+
+        await _publishContentfulWebhook.Consume(entry, "ContentManagement.Entry.publish");
+
+        _logger.Received(1).Log(
+            LogLevel.Error,
+            Arg.Any<EventId>(),
+            Arg.Is<object>(v => v.ToString()!.Contains($"Error Publishing Linked Page: {pageSlug}")),
+            Arg.Is<ContentfulException>(e => e.Message == "Error"),
+            Arg.Any<Func<object, Exception?, string>>());
     }
 
     private static Entry<ContentfulContent> CreateEntry(string contentType, string entryId) =>


### PR DESCRIPTION
Ticket: [CL-22](https://dfedigital.atlassian.net/browse/CL-22)

This PR:

- Refactors the webhooks to use some shared common code
- Refactors such that code is easier to understand and maintain, things are generally shorter
- Adds a readme to explain what the purpose of the webhook consumers is
- Adds a couple extra tests

I would like to revisit the caching system as a whole and see if anything can be simplified a bit further, but that'd be out of scope and for now the same functionality is maintained