### PR TITLE
feat!(CL-340-343): Circuit Breaking Azure Translation & PDF Generation

### DIFF
--- a/src/web/CareLeavers.Web/CircuitBreaker/CircuitBreakerService.cs
+++ b/src/web/CareLeavers.Web/CircuitBreaker/CircuitBreakerService.cs
@@ -10,40 +10,40 @@ public sealed class CircuitBreakerService(IHttpContextAccessor accessor, IOption
 
     public bool ShouldBreakCircuit(CircuitBreakerType circuit)
     {
-        if (accessor.HttpContext is null) throw new ArgumentNullException(nameof(accessor.HttpContext));
+        if (accessor.HttpContext is null) throw new InvalidOperationException("HttpContext is NULL");
+        HttpContext httpContext = accessor.HttpContext;
 
         return circuit switch
         {
-            CircuitBreakerType.AzureTranslation => ShouldBreakCircuitAzureTranslation(),
-            CircuitBreakerType.PdfGenerator => ShouldBreakCircuitPdfGenerator(),
-            _ => throw new ArgumentOutOfRangeException(nameof(circuit), circuit, "Invalid Circuit Breaker Option")
+            CircuitBreakerType.AzureTranslation => ShouldBreakCircuitAzureTranslation(httpContext),
+            CircuitBreakerType.PdfGenerator => ShouldBreakCircuitPdfGenerator(httpContext),
+            _ => throw new ArgumentOutOfRangeException(nameof(circuit))
         };
     }
 
-    private bool ShouldBreakCircuitAzureTranslation()
+    private bool ShouldBreakCircuitAzureTranslation(HttpContext httpContext)
     {
-        string? languageCode = accessor.HttpContext?.Request.RouteValues["languageCode"]?.ToString();
+        string? languageCode = httpContext.Request.RouteValues["languageCode"]?.ToString();
 
         if (languageCode is null or "en") return false;
 
-        string? json = accessor.HttpContext?.Session.GetString(CircuitBreakerOptions.AzureTranslationKey);
+        string? json = httpContext.Session.GetString(CircuitBreakerOptions.AzureTranslationKey);
         List<string> translatedLanguages = json is null ? [] : JsonSerializer.Deserialize<List<string>>(json) ?? [];
 
         if (translatedLanguages.Contains(languageCode)) return false;
         if (translatedLanguages.Count >= options.Value.AzureTranslationLimit) return true;
 
-        translatedLanguages.Add(languageCode);
-        accessor.HttpContext?.Session.SetString(CircuitBreakerOptions.AzureTranslationKey,
-            JsonSerializer.Serialize(translatedLanguages, JsonSerializerOptions));
+        translatedLanguages.Add(languageCode); 
+        httpContext.Session.SetString(CircuitBreakerOptions.AzureTranslationKey, JsonSerializer.Serialize(translatedLanguages, JsonSerializerOptions));
 
         return false;
     }
 
-    private bool ShouldBreakCircuitPdfGenerator()
+    private bool ShouldBreakCircuitPdfGenerator(HttpContext httpContext)
     {
-        int timesUsed = accessor.HttpContext?.Session.GetInt32(CircuitBreakerOptions.PdfGeneratorKey) ?? 0;
+        int timesUsed = httpContext.Session.GetInt32(CircuitBreakerOptions.PdfGeneratorKey) ?? 0;
         if (timesUsed >= options.Value.PdfGeneratorLimit) return true;
-        accessor.HttpContext?.Session.SetInt32(CircuitBreakerOptions.PdfGeneratorKey, timesUsed + 1);
+        httpContext.Session.SetInt32(CircuitBreakerOptions.PdfGeneratorKey, timesUsed + 1);
         return false;
     }
 }

--- a/src/web/CareLeavers.Web/CircuitBreaker/CircuitBreakerService.cs
+++ b/src/web/CareLeavers.Web/CircuitBreaker/CircuitBreakerService.cs
@@ -1,0 +1,49 @@
+using System.Text.Json;
+using CareLeavers.Web.Configuration;
+using Microsoft.Extensions.Options;
+
+namespace CareLeavers.Web.CircuitBreaker;
+
+public sealed class CircuitBreakerService(IHttpContextAccessor accessor, IOptions<CircuitBreakerOptions> options)
+{
+    private static readonly JsonSerializerOptions JsonSerializerOptions = new(JsonSerializerDefaults.Web);
+
+    public bool ShouldBreakCircuit(CircuitBreakerType circuit)
+    {
+        if (accessor.HttpContext is null) throw new ArgumentNullException(nameof(accessor.HttpContext));
+
+        return circuit switch
+        {
+            CircuitBreakerType.AzureTranslation => ShouldBreakCircuitAzureTranslation(),
+            CircuitBreakerType.PdfGenerator => ShouldBreakCircuitPdfGenerator(),
+            _ => throw new ArgumentOutOfRangeException(nameof(circuit), circuit, "Invalid Circuit Breaker Option")
+        };
+    }
+
+    private bool ShouldBreakCircuitAzureTranslation()
+    {
+        string? languageCode = accessor.HttpContext?.Request.RouteValues["languageCode"]?.ToString();
+
+        if (languageCode is null or "en") return false;
+
+        string? json = accessor.HttpContext?.Session.GetString(CircuitBreakerOptions.AzureTranslationKey);
+        List<string> translatedLanguages = json is null ? [] : JsonSerializer.Deserialize<List<string>>(json) ?? [];
+
+        if (translatedLanguages.Contains(languageCode)) return false;
+        if (translatedLanguages.Count >= options.Value.AzureTranslationLimit) return true;
+
+        translatedLanguages.Add(languageCode);
+        accessor.HttpContext?.Session.SetString(CircuitBreakerOptions.AzureTranslationKey,
+            JsonSerializer.Serialize(translatedLanguages, JsonSerializerOptions));
+
+        return false;
+    }
+
+    private bool ShouldBreakCircuitPdfGenerator()
+    {
+        int timesUsed = accessor.HttpContext?.Session.GetInt32(CircuitBreakerOptions.PdfGeneratorKey) ?? 0;
+        if (timesUsed >= options.Value.PdfGeneratorLimit) return true;
+        accessor.HttpContext?.Session.SetInt32(CircuitBreakerOptions.PdfGeneratorKey, timesUsed + 1);
+        return false;
+    }
+}

--- a/src/web/CareLeavers.Web/CircuitBreaker/CircuitBreakerType.cs
+++ b/src/web/CareLeavers.Web/CircuitBreaker/CircuitBreakerType.cs
@@ -1,0 +1,7 @@
+namespace CareLeavers.Web.CircuitBreaker;
+
+public enum CircuitBreakerType
+{
+    AzureTranslation,
+    PdfGenerator
+}

--- a/src/web/CareLeavers.Web/Configuration/CircuitBreakerOptions.cs
+++ b/src/web/CareLeavers.Web/Configuration/CircuitBreakerOptions.cs
@@ -1,0 +1,16 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace CareLeavers.Web.Configuration;
+
+[ExcludeFromCodeCoverage(Justification = "Configuration")]
+public class CircuitBreakerOptions
+{
+    public const string Name = "CircuitBreaker";
+
+    public const string AzureTranslationKey = "_AzureTranslation";
+    public const string PdfGeneratorKey = "_PdfGenerator";
+
+    public int AzureTranslationLimit { get; set; }
+    
+    public int PdfGeneratorLimit { get; set; }
+}

--- a/src/web/CareLeavers.Web/Controllers/PagesController.cs
+++ b/src/web/CareLeavers.Web/Controllers/PagesController.cs
@@ -1,6 +1,7 @@
 using CareLeavers.Web.Contentful;
 using CareLeavers.Web.Filters;
 using CareLeavers.Web.Models;
+using CareLeavers.Web.Models.Content;
 using CareLeavers.Web.Models.ViewModels;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Mvc;
@@ -94,5 +95,14 @@ public class PagesController(IContentService contentService) : Controller
         cookiePolicyModel.ShowSuccessBanner = true;
         
         return View("CookiePolicy", cookiePolicyModel);
+    }
+
+    [Route("/{languageCode}/translation-limit-reached")]
+    [Route("/translation-limit-reached")]
+    public async Task<IActionResult> TranslationLimitReached(string? languageCode)
+    {
+        Page? page = await contentService.GetPage("translation-limit-reached");
+
+        return page is not null ? View(page) : NotFound();
     }
 }

--- a/src/web/CareLeavers.Web/Controllers/PrintController.cs
+++ b/src/web/CareLeavers.Web/Controllers/PrintController.cs
@@ -1,4 +1,5 @@
 using System.Net.Http.Headers;
+using CareLeavers.Web.CircuitBreaker;
 using CareLeavers.Web.Configuration;
 using CareLeavers.Web.Contentful;
 using CareLeavers.Web.Filters;
@@ -55,10 +56,9 @@ public class PrintController(IHttpClientFactory httpClientFactory, IContentServi
     }
 
     [Route("/pdf/{languageCode}/{identifier}")]
-    public async Task<IActionResult> DownloadPdf(string identifier, string languageCode)
+    public async Task<IActionResult> DownloadPdf([FromServices] CircuitBreakerService circuitBreakerService, 
+        string identifier, string languageCode)
     {
-
-
         var collection = await contentService.GetPrintableCollection(identifier);
         if (collection == null)
             return NotFound();
@@ -79,6 +79,8 @@ public class PrintController(IHttpClientFactory httpClientFactory, IContentServi
         {
             var pdf = await fusionCache.GetOrSetAsync<byte[]>($"pdf:{identifier}:{languageCode}", async token =>
             {
+                if (circuitBreakerService.ShouldBreakCircuit(CircuitBreakerType.PdfGenerator)) return [];
+                
                 var config = await contentService.GetConfiguration();
 
                 var url = Url.ActionLink("GetPrintableCollection", "Print", new { identifier, languageCode }, protocol: "https");

--- a/src/web/CareLeavers.Web/Filters/TranslationAttribute.cs
+++ b/src/web/CareLeavers.Web/Filters/TranslationAttribute.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using CareLeavers.Web.CircuitBreaker;
 using CareLeavers.Web.Configuration;
 using CareLeavers.Web.Models.Content;
 using CareLeavers.Web.Translation;
@@ -23,6 +24,16 @@ public class TranslationAttribute : ActionFilterAttribute
     {
         _memoryStream = null;
         _originalBodyStream = null;
+        
+        CircuitBreakerService circuitBreakerService = 
+            context.HttpContext.RequestServices.GetRequiredService<CircuitBreakerService>();
+
+        if (circuitBreakerService.ShouldBreakCircuit(CircuitBreakerType.AzureTranslation))
+        {
+            context.Result = new RedirectToActionResult("TranslationLimitReached", "Pages", null);
+            await base.OnActionExecutionAsync(context, next);
+            return;
+        }
 
         var fusionCache = context.HttpContext.RequestServices.GetRequiredService<IFusionCache>();
         var translationService = context.HttpContext.RequestServices.GetRequiredService<ITranslationService>();

--- a/src/web/CareLeavers.Web/Program.cs
+++ b/src/web/CareLeavers.Web/Program.cs
@@ -139,6 +139,7 @@ try
     {
         options.Cookie.Name = ".SupportForCareLeavers.Session";
         options.Cookie.IsEssential = true;
+        options.Cookie.MaxAge = FromDays(1);
         options.IdleTimeout = FromDays(1);
     });
     

--- a/src/web/CareLeavers.Web/Program.cs
+++ b/src/web/CareLeavers.Web/Program.cs
@@ -5,6 +5,7 @@ using Azure.AI.Translation.Document;
 using Azure.AI.Translation.Text;
 using Azure.Monitor.OpenTelemetry.AspNetCore;
 using CareLeavers.Web;
+using CareLeavers.Web.CircuitBreaker;
 using CareLeavers.Web.Configuration;
 using CareLeavers.Web.Contentful;
 using CareLeavers.Web.Contentful.Webhooks;
@@ -30,7 +31,6 @@ using OpenTelemetry.Trace;
 using Serilog;
 using WebMarkupMin.AspNet.Common.Compressors;
 using WebMarkupMin.AspNetCoreLatest;
-using WebMarkupMin.Core;
 using ZiggyCreatures.Caching.Fusion;
 using static System.TimeSpan;
 
@@ -133,6 +133,19 @@ try
     
     #endregion
     
+    #region Session State & Circuit Breaking
+    
+    builder.Services.AddSession(options =>
+    {
+        options.Cookie.Name = ".SupportForCareLeavers.Session";
+        options.Cookie.IsEssential = true;
+        options.IdleTimeout = FromDays(1);
+    });
+    
+    builder.Services.AddTransient<CircuitBreakerService>();
+    
+    #endregion
+    
     #region GetToAnAnswer
 
     var gtaaBaseUrl = builder.Configuration.GetSection("GetToAnAnswer:BaseUrl").Value!;
@@ -200,6 +213,7 @@ try
     builder.Services.AddOptions<CachingOptions>().BindConfiguration(CachingOptions.Name);
     builder.Services.AddOptions<PdfGenerationOptions>().BindConfiguration(PdfGenerationOptions.Name);
     builder.Services.AddOptions<AzureTranslationOptions>().BindConfiguration(AzureTranslationOptions.Name);
+    builder.Services.AddOptions<CircuitBreakerOptions>().BindConfiguration(CircuitBreakerOptions.Name);
     
     if (string.IsNullOrEmpty(builder.Configuration.GetValue<string>("AzureTranslation:AccessKey")))
     {
@@ -562,6 +576,7 @@ try
         }
     });
     app.UseRouting();
+    app.UseSession();
     app.MapHealthChecks("/health");
     app.MapControllerRoute(
         name: "default",

--- a/src/web/CareLeavers.Web/Views/Pages/CookiePolicy.cshtml
+++ b/src/web/CareLeavers.Web/Views/Pages/CookiePolicy.cshtml
@@ -116,6 +116,17 @@ else
                 Session
             </td>
         </tr>
+        <tr>
+            <td class="govuk-table__cell">
+                .SupportForCareLeavers.Session
+            </td>
+            <td class="govuk-table__cell">
+                Used to limit the number of times the translation feature can be used
+            </td>
+            <td class="govuk-table__cell">
+                1 day
+            </td>
+        </tr>
         </tbody>
     </table>
     <hr class="govuk-section-break govuk-section-break--l g"/>

--- a/src/web/CareLeavers.Web/Views/Pages/TranslationLimitReached.cshtml
+++ b/src/web/CareLeavers.Web/Views/Pages/TranslationLimitReached.cshtml
@@ -1,0 +1,23 @@
+@model CareLeavers.Web.Models.Content.Page
+@{
+    ViewBag.Title = Model.Title;
+    Layout = "_Layout";
+}
+
+@section Head
+{
+    <meta name="robots" content="noindex, nofollow"/>
+}
+
+@section BeforeGDSContent
+{
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <h1 class="govuk-heading-xl">
+                @ViewBag.Title
+            </h1>
+        </div>
+    </div>
+}
+
+<gds-contentful-rich-text document="@Model.MainContent"/>

--- a/src/web/CareLeavers.Web/appsettings.json
+++ b/src/web/CareLeavers.Web/appsettings.json
@@ -41,6 +41,10 @@
     "AccessKey": "",
     "Region": "uksouth"
   },
+  "CircuitBreaker": {
+    "AzureTranslationLimit": 1,
+    "PdfGeneratorLimit": 10
+  },
   "Csp": {
     "AllowScriptUrls": [
       "cdn.openshareweb.com",

--- a/src/web/CareLeavers.Web/appsettings.json
+++ b/src/web/CareLeavers.Web/appsettings.json
@@ -42,7 +42,7 @@
     "Region": "uksouth"
   },
   "CircuitBreaker": {
-    "AzureTranslationLimit": 1,
+    "AzureTranslationLimit": 5,
     "PdfGeneratorLimit": 10
   },
   "Csp": {

--- a/src/web/tests/CareLeavers.Web.Tests/CircuitBreaker/CircuitBreakerServiceTests.cs
+++ b/src/web/tests/CareLeavers.Web.Tests/CircuitBreaker/CircuitBreakerServiceTests.cs
@@ -32,27 +32,29 @@ public class CircuitBreakerServiceTests
     }
 
     [Test]
-    public void ShouldBreakCircuit_When_HttpContextIsNull_Throws_ArgumentNullException()
+    public void ShouldBreakCircuit_When_HttpContextIsNull_Throws_InvalidOperationException()
     {
         _httpContextAccessor.HttpContext = null;
 
-        Assert.Throws<ArgumentNullException>(() =>
-            _circuitBreakerService.ShouldBreakCircuit(CircuitBreakerType.AzureTranslation));
+        Assert.That(() => _circuitBreakerService.ShouldBreakCircuit(CircuitBreakerType.AzureTranslation),
+            Throws.TypeOf<InvalidOperationException>().With.Message.EqualTo("HttpContext is NULL"));
     }
 
     [Test]
     public void ShouldBreakCircuit_When_CircuitBreakerType_IsNull_Throws_ArgumentOutOfRangeException()
     {
-        Assert.Throws<ArgumentOutOfRangeException>(() => _circuitBreakerService.ShouldBreakCircuit((CircuitBreakerType)2));
+        Assert.That(() => _circuitBreakerService.ShouldBreakCircuit((CircuitBreakerType)2),
+            Throws.TypeOf<ArgumentOutOfRangeException>().With.Message
+                .EqualTo("Specified argument was out of the range of valid values. (Parameter 'circuit')"));
     }
 
     [Test]
     public void ShouldBreakCircuit_AzureTranslation_When_LanguageCode_IsNull_Returns_False()
     {
         _httpContext.Request.RouteValues["languageCode"] = null;
-        
+
         bool result = _circuitBreakerService.ShouldBreakCircuit(CircuitBreakerType.AzureTranslation);
-        
+
         Assert.That(result, Is.False);
     }
 
@@ -60,9 +62,9 @@ public class CircuitBreakerServiceTests
     public void ShouldBreakCircuit_AzureTranslation_When_LanguageCode_IsEnglish_Returns_False()
     {
         _httpContext.Request.RouteValues["languageCode"] = "en";
-        
+
         bool result = _circuitBreakerService.ShouldBreakCircuit(CircuitBreakerType.AzureTranslation);
-        
+
         Assert.That(result, Is.False);
     }
 
@@ -70,13 +72,14 @@ public class CircuitBreakerServiceTests
     public void ShouldBreakCircuit_AzureTranslation_When_JsonIsNull_Returns_False()
     {
         _httpContext.Request.RouteValues["languageCode"] = "sv";
-        
+
         bool result = _circuitBreakerService.ShouldBreakCircuit(CircuitBreakerType.AzureTranslation);
-        
+
         using (Assert.EnterMultipleScope())
         {
             Assert.That(result, Is.False);
-            Assert.That(_httpContext.Session.GetString(CircuitBreakerOptions.AzureTranslationKey), Is.EqualTo(JsonSerializer.Serialize(new List<string> { "sv" })));
+            Assert.That(_httpContext.Session.GetString(CircuitBreakerOptions.AzureTranslationKey),
+                Is.EqualTo(JsonSerializer.Serialize(new List<string> { "sv" })));
         }
     }
 
@@ -85,13 +88,14 @@ public class CircuitBreakerServiceTests
     {
         _httpContext.Request.RouteValues["languageCode"] = "sv";
         _httpContext.Session.SetString(CircuitBreakerOptions.AzureTranslationKey, "null");
-        
+
         bool result = _circuitBreakerService.ShouldBreakCircuit(CircuitBreakerType.AzureTranslation);
-        
+
         using (Assert.EnterMultipleScope())
         {
             Assert.That(result, Is.False);
-            Assert.That(_httpContext.Session.GetString(CircuitBreakerOptions.AzureTranslationKey), Is.EqualTo(JsonSerializer.Serialize(new List<string> { "sv" })));
+            Assert.That(_httpContext.Session.GetString(CircuitBreakerOptions.AzureTranslationKey),
+                Is.EqualTo(JsonSerializer.Serialize(new List<string> { "sv" })));
         }
     }
 
@@ -99,21 +103,23 @@ public class CircuitBreakerServiceTests
     public void ShouldBreakCircuit_AzureTranslation_When_LanguagePreviouslyTranslated_Returns_False()
     {
         _httpContext.Request.RouteValues["languageCode"] = "sv";
-        _httpContext.Session.SetString(CircuitBreakerOptions.AzureTranslationKey, JsonSerializer.Serialize(new List<string> { "sv" }));
-        
+        _httpContext.Session.SetString(CircuitBreakerOptions.AzureTranslationKey,
+            JsonSerializer.Serialize(new List<string> { "sv" }));
+
         bool result = _circuitBreakerService.ShouldBreakCircuit(CircuitBreakerType.AzureTranslation);
-        
+
         Assert.That(result, Is.False);
     }
-    
+
     [Test]
     public void ShouldBreakCircuit_AzureTranslation_When_AtLimit_But_LanguagePreviouslyTranslated_Returns_False()
     {
         _httpContext.Request.RouteValues["languageCode"] = "sv";
-        _httpContext.Session.SetString(CircuitBreakerOptions.AzureTranslationKey, JsonSerializer.Serialize(new List<string> { "sv", "fr" }));
-        
+        _httpContext.Session.SetString(CircuitBreakerOptions.AzureTranslationKey,
+            JsonSerializer.Serialize(new List<string> { "sv", "fr" }));
+
         bool result = _circuitBreakerService.ShouldBreakCircuit(CircuitBreakerType.AzureTranslation);
-        
+
         Assert.That(result, Is.False);
     }
 
@@ -121,10 +127,11 @@ public class CircuitBreakerServiceTests
     public void ShouldBreakCircuit_AzureTranslation_When_LimitIsReached_Returns_True()
     {
         _httpContext.Request.RouteValues["languageCode"] = "sv";
-        _httpContext.Session.SetString(CircuitBreakerOptions.AzureTranslationKey, JsonSerializer.Serialize(new List<string> { "es", "fr" }));
-        
+        _httpContext.Session.SetString(CircuitBreakerOptions.AzureTranslationKey,
+            JsonSerializer.Serialize(new List<string> { "es", "fr" }));
+
         bool result = _circuitBreakerService.ShouldBreakCircuit(CircuitBreakerType.AzureTranslation);
-        
+
         Assert.That(result, Is.True);
     }
 
@@ -132,14 +139,16 @@ public class CircuitBreakerServiceTests
     public void ShouldBreakCircuit_AzureTranslation_When_LimitIsNotReached_Returns_False_And_UpdatesSession()
     {
         _httpContext.Request.RouteValues["languageCode"] = "sv";
-        _httpContext.Session.SetString(CircuitBreakerOptions.AzureTranslationKey, JsonSerializer.Serialize(new List<string> { "es" }));
-        
+        _httpContext.Session.SetString(CircuitBreakerOptions.AzureTranslationKey,
+            JsonSerializer.Serialize(new List<string> { "es" }));
+
         bool result = _circuitBreakerService.ShouldBreakCircuit(CircuitBreakerType.AzureTranslation);
-        
+
         using (Assert.EnterMultipleScope())
         {
             Assert.That(result, Is.False);
-            Assert.That(_httpContext.Session.GetString(CircuitBreakerOptions.AzureTranslationKey), Is.EqualTo(JsonSerializer.Serialize(new List<string> { "es", "sv" })));
+            Assert.That(_httpContext.Session.GetString(CircuitBreakerOptions.AzureTranslationKey),
+                Is.EqualTo(JsonSerializer.Serialize(new List<string> { "es", "sv" })));
         }
     }
 
@@ -147,7 +156,7 @@ public class CircuitBreakerServiceTests
     public void ShouldBreakCircuit_PdfGenerator_When_FirstUsage_Returns_False_And_UpdatesSession()
     {
         bool result = _circuitBreakerService.ShouldBreakCircuit(CircuitBreakerType.PdfGenerator);
-        
+
         using (Assert.EnterMultipleScope())
         {
             Assert.That(result, Is.False);
@@ -159,7 +168,7 @@ public class CircuitBreakerServiceTests
     public void ShouldBreakCircuit_PdfGenerator_When_BelowLimit_Returns_False_And_UpdatesSession()
     {
         _httpContext.Session.SetInt32(CircuitBreakerOptions.PdfGeneratorKey, 1);
-        
+
         bool result = _circuitBreakerService.ShouldBreakCircuit(CircuitBreakerType.PdfGenerator);
 
         using (Assert.EnterMultipleScope())
@@ -173,9 +182,9 @@ public class CircuitBreakerServiceTests
     public void ShouldBreakCircuit_PdfGenerator_When_LimitIsReached_Returns_True()
     {
         _httpContext.Session.SetInt32(CircuitBreakerOptions.PdfGeneratorKey, 2);
-        
+
         bool result = _circuitBreakerService.ShouldBreakCircuit(CircuitBreakerType.PdfGenerator);
-        
+
         Assert.That(result, Is.True);
     }
 }

--- a/src/web/tests/CareLeavers.Web.Tests/CircuitBreaker/CircuitBreakerServiceTests.cs
+++ b/src/web/tests/CareLeavers.Web.Tests/CircuitBreaker/CircuitBreakerServiceTests.cs
@@ -1,0 +1,114 @@
+using System.Text.Json;
+using CareLeavers.Web.CircuitBreaker;
+using CareLeavers.Web.Configuration;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+
+namespace CareLeavers.Web.Tests.CircuitBreaker;
+
+public class CircuitBreakerServiceTests
+{
+    private IHttpContextAccessor _httpContextAccessor;
+    private HttpContext _httpContext;
+    private IOptions<CircuitBreakerOptions> _circuitBreakerOptions;
+    private CircuitBreakerService _circuitBreakerService;
+
+    [SetUp]
+    public void Init()
+    {
+        _httpContextAccessor = Substitute.For<IHttpContextAccessor>();
+        _httpContext = new DefaultHttpContext();
+        _httpContext.Session = new MockSession();
+        _httpContextAccessor.HttpContext = _httpContext;
+        
+        _circuitBreakerOptions = Options.Create(new CircuitBreakerOptions 
+        { 
+            AzureTranslationLimit = 2,
+            PdfGeneratorLimit = 2
+        });
+        
+        _circuitBreakerService = new CircuitBreakerService(_httpContextAccessor, _circuitBreakerOptions);
+    }
+
+    [Test]
+    public void ShouldBreakCircuitAzureTranslation_WhenLanguageIsEnglish_ReturnsFalse()
+    {
+        _httpContext.Request.RouteValues["languageCode"] = "en";
+        
+        bool result = _circuitBreakerService.ShouldBreakCircuit(CircuitBreakerType.AzureTranslation);
+        
+        Assert.That(result, Is.False);
+    }
+
+    [Test]
+    public void ShouldBreakCircuitAzureTranslation_WhenLanguageIsNotEnglishAndLimitNotReached_ReturnsFalseAndAddsToSession()
+    {
+        _httpContext.Request.RouteValues["languageCode"] = "sv";
+        
+        bool result = _circuitBreakerService.ShouldBreakCircuit(CircuitBreakerType.AzureTranslation);
+        
+        Assert.That(result, Is.False);
+        
+        string? json = _httpContext.Session.GetString(CircuitBreakerOptions.AzureTranslationKey);
+        Assert.That(json, Is.Not.Null);
+        List<string>? translatedLanguages = JsonSerializer.Deserialize<List<string>>(json);
+        Assert.That(translatedLanguages, Is.Not.Null);
+        Assert.That(translatedLanguages, Is.Not.Empty);
+        Assert.That(translatedLanguages, Contains.Item("sv"));
+    }
+
+    [Test]
+    public void ShouldBreakCircuitAzureTranslation_WhenLanguagePreviouslyTranslated_ReturnsFalse()
+    {
+        _httpContext.Request.RouteValues["languageCode"] = "sv";
+        _httpContext.Session.SetString(CircuitBreakerOptions.AzureTranslationKey, JsonSerializer.Serialize(new List<string> { "sv" }));
+        
+        bool result = _circuitBreakerService.ShouldBreakCircuit(CircuitBreakerType.AzureTranslation);
+        
+        Assert.That(result, Is.False);
+    }
+
+    [Test]
+    public void ShouldBreakCircuitAzureTranslation_WhenLimitReached_ReturnsTrue()
+    {
+        _httpContext.Request.RouteValues["languageCode"] = "es";
+        _httpContext.Session.SetString(CircuitBreakerOptions.AzureTranslationKey, JsonSerializer.Serialize(new List<string> { "sv", "fr" }));
+        
+        bool result = _circuitBreakerService.ShouldBreakCircuit(CircuitBreakerType.AzureTranslation);
+        
+        Assert.That(result, Is.True);
+    }
+
+    [Test]
+    public void ShouldBreakCircuitPdfGenerator_WhenUsageBelowLimit_ReturnsFalseAndIncrementsCount()
+    {
+        bool result = _circuitBreakerService.ShouldBreakCircuit(CircuitBreakerType.PdfGenerator);
+        
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result, Is.False);
+            Assert.That(_httpContext.Session.GetInt32(CircuitBreakerOptions.PdfGeneratorKey), Is.EqualTo(1));
+        }
+    }
+
+    [Test]
+    public void ShouldBreakCircuitPdfGenerator_WhenUsageAtLimit_ReturnsTrue()
+    {
+        _httpContext.Session.SetInt32(CircuitBreakerOptions.PdfGeneratorKey, 2);
+        
+        bool result = _circuitBreakerService.ShouldBreakCircuit(CircuitBreakerType.PdfGenerator);
+        
+        Assert.That(result, Is.True);
+    }
+
+    [Test]
+    public void ShouldBreakCircuitPdfGenerator_WhenUsageExceedsLimit_ReturnsTrue()
+    {
+        _httpContext.Session.SetInt32(CircuitBreakerOptions.PdfGeneratorKey, 3);
+        
+        bool result = _circuitBreakerService.ShouldBreakCircuit(CircuitBreakerType.PdfGenerator);
+        
+        Assert.That(result, Is.True);
+    }
+}

--- a/src/web/tests/CareLeavers.Web.Tests/CircuitBreaker/CircuitBreakerServiceTests.cs
+++ b/src/web/tests/CareLeavers.Web.Tests/CircuitBreaker/CircuitBreakerServiceTests.cs
@@ -21,18 +21,43 @@ public class CircuitBreakerServiceTests
         _httpContext = new DefaultHttpContext();
         _httpContext.Session = new MockSession();
         _httpContextAccessor.HttpContext = _httpContext;
-        
-        _circuitBreakerOptions = Options.Create(new CircuitBreakerOptions 
-        { 
+
+        _circuitBreakerOptions = Options.Create(new CircuitBreakerOptions
+        {
             AzureTranslationLimit = 2,
             PdfGeneratorLimit = 2
         });
-        
+
         _circuitBreakerService = new CircuitBreakerService(_httpContextAccessor, _circuitBreakerOptions);
     }
 
     [Test]
-    public void ShouldBreakCircuitAzureTranslation_WhenLanguageIsEnglish_ReturnsFalse()
+    public void ShouldBreakCircuit_When_HttpContextIsNull_Throws_ArgumentNullException()
+    {
+        _httpContextAccessor.HttpContext = null;
+
+        Assert.Throws<ArgumentNullException>(() =>
+            _circuitBreakerService.ShouldBreakCircuit(CircuitBreakerType.AzureTranslation));
+    }
+
+    [Test]
+    public void ShouldBreakCircuit_When_CircuitBreakerType_IsNull_Throws_ArgumentOutOfRangeException()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => _circuitBreakerService.ShouldBreakCircuit((CircuitBreakerType)2));
+    }
+
+    [Test]
+    public void ShouldBreakCircuit_AzureTranslation_When_LanguageCode_IsNull_Returns_False()
+    {
+        _httpContext.Request.RouteValues["languageCode"] = null;
+        
+        bool result = _circuitBreakerService.ShouldBreakCircuit(CircuitBreakerType.AzureTranslation);
+        
+        Assert.That(result, Is.False);
+    }
+
+    [Test]
+    public void ShouldBreakCircuit_AzureTranslation_When_LanguageCode_IsEnglish_Returns_False()
     {
         _httpContext.Request.RouteValues["languageCode"] = "en";
         
@@ -42,24 +67,36 @@ public class CircuitBreakerServiceTests
     }
 
     [Test]
-    public void ShouldBreakCircuitAzureTranslation_WhenLanguageIsNotEnglishAndLimitNotReached_ReturnsFalseAndAddsToSession()
+    public void ShouldBreakCircuit_AzureTranslation_When_JsonIsNull_Returns_False()
     {
         _httpContext.Request.RouteValues["languageCode"] = "sv";
         
         bool result = _circuitBreakerService.ShouldBreakCircuit(CircuitBreakerType.AzureTranslation);
         
-        Assert.That(result, Is.False);
-        
-        string? json = _httpContext.Session.GetString(CircuitBreakerOptions.AzureTranslationKey);
-        Assert.That(json, Is.Not.Null);
-        List<string>? translatedLanguages = JsonSerializer.Deserialize<List<string>>(json);
-        Assert.That(translatedLanguages, Is.Not.Null);
-        Assert.That(translatedLanguages, Is.Not.Empty);
-        Assert.That(translatedLanguages, Contains.Item("sv"));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result, Is.False);
+            Assert.That(_httpContext.Session.GetString(CircuitBreakerOptions.AzureTranslationKey), Is.EqualTo(JsonSerializer.Serialize(new List<string> { "sv" })));
+        }
     }
 
     [Test]
-    public void ShouldBreakCircuitAzureTranslation_WhenLanguagePreviouslyTranslated_ReturnsFalse()
+    public void ShouldBreakCircuit_AzureTranslation_When_JsonValueIsNull_Returns_False()
+    {
+        _httpContext.Request.RouteValues["languageCode"] = "sv";
+        _httpContext.Session.SetString(CircuitBreakerOptions.AzureTranslationKey, "null");
+        
+        bool result = _circuitBreakerService.ShouldBreakCircuit(CircuitBreakerType.AzureTranslation);
+        
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result, Is.False);
+            Assert.That(_httpContext.Session.GetString(CircuitBreakerOptions.AzureTranslationKey), Is.EqualTo(JsonSerializer.Serialize(new List<string> { "sv" })));
+        }
+    }
+
+    [Test]
+    public void ShouldBreakCircuit_AzureTranslation_When_LanguagePreviouslyTranslated_Returns_False()
     {
         _httpContext.Request.RouteValues["languageCode"] = "sv";
         _httpContext.Session.SetString(CircuitBreakerOptions.AzureTranslationKey, JsonSerializer.Serialize(new List<string> { "sv" }));
@@ -68,12 +105,23 @@ public class CircuitBreakerServiceTests
         
         Assert.That(result, Is.False);
     }
+    
+    [Test]
+    public void ShouldBreakCircuit_AzureTranslation_When_AtLimit_But_LanguagePreviouslyTranslated_Returns_False()
+    {
+        _httpContext.Request.RouteValues["languageCode"] = "sv";
+        _httpContext.Session.SetString(CircuitBreakerOptions.AzureTranslationKey, JsonSerializer.Serialize(new List<string> { "sv", "fr" }));
+        
+        bool result = _circuitBreakerService.ShouldBreakCircuit(CircuitBreakerType.AzureTranslation);
+        
+        Assert.That(result, Is.False);
+    }
 
     [Test]
-    public void ShouldBreakCircuitAzureTranslation_WhenLimitReached_ReturnsTrue()
+    public void ShouldBreakCircuit_AzureTranslation_When_LimitIsReached_Returns_True()
     {
-        _httpContext.Request.RouteValues["languageCode"] = "es";
-        _httpContext.Session.SetString(CircuitBreakerOptions.AzureTranslationKey, JsonSerializer.Serialize(new List<string> { "sv", "fr" }));
+        _httpContext.Request.RouteValues["languageCode"] = "sv";
+        _httpContext.Session.SetString(CircuitBreakerOptions.AzureTranslationKey, JsonSerializer.Serialize(new List<string> { "es", "fr" }));
         
         bool result = _circuitBreakerService.ShouldBreakCircuit(CircuitBreakerType.AzureTranslation);
         
@@ -81,7 +129,22 @@ public class CircuitBreakerServiceTests
     }
 
     [Test]
-    public void ShouldBreakCircuitPdfGenerator_WhenUsageBelowLimit_ReturnsFalseAndIncrementsCount()
+    public void ShouldBreakCircuit_AzureTranslation_When_LimitIsNotReached_Returns_False_And_UpdatesSession()
+    {
+        _httpContext.Request.RouteValues["languageCode"] = "sv";
+        _httpContext.Session.SetString(CircuitBreakerOptions.AzureTranslationKey, JsonSerializer.Serialize(new List<string> { "es" }));
+        
+        bool result = _circuitBreakerService.ShouldBreakCircuit(CircuitBreakerType.AzureTranslation);
+        
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result, Is.False);
+            Assert.That(_httpContext.Session.GetString(CircuitBreakerOptions.AzureTranslationKey), Is.EqualTo(JsonSerializer.Serialize(new List<string> { "es", "sv" })));
+        }
+    }
+
+    [Test]
+    public void ShouldBreakCircuit_PdfGenerator_When_FirstUsage_Returns_False_And_UpdatesSession()
     {
         bool result = _circuitBreakerService.ShouldBreakCircuit(CircuitBreakerType.PdfGenerator);
         
@@ -93,19 +156,23 @@ public class CircuitBreakerServiceTests
     }
 
     [Test]
-    public void ShouldBreakCircuitPdfGenerator_WhenUsageAtLimit_ReturnsTrue()
+    public void ShouldBreakCircuit_PdfGenerator_When_BelowLimit_Returns_False_And_UpdatesSession()
     {
-        _httpContext.Session.SetInt32(CircuitBreakerOptions.PdfGeneratorKey, 2);
+        _httpContext.Session.SetInt32(CircuitBreakerOptions.PdfGeneratorKey, 1);
         
         bool result = _circuitBreakerService.ShouldBreakCircuit(CircuitBreakerType.PdfGenerator);
-        
-        Assert.That(result, Is.True);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result, Is.False);
+            Assert.That(_httpContext.Session.GetInt32(CircuitBreakerOptions.PdfGeneratorKey), Is.EqualTo(2));
+        }
     }
 
     [Test]
-    public void ShouldBreakCircuitPdfGenerator_WhenUsageExceedsLimit_ReturnsTrue()
+    public void ShouldBreakCircuit_PdfGenerator_When_LimitIsReached_Returns_True()
     {
-        _httpContext.Session.SetInt32(CircuitBreakerOptions.PdfGeneratorKey, 3);
+        _httpContext.Session.SetInt32(CircuitBreakerOptions.PdfGeneratorKey, 2);
         
         bool result = _circuitBreakerService.ShouldBreakCircuit(CircuitBreakerType.PdfGenerator);
         

--- a/src/web/tests/CareLeavers.Web.Tests/Controllers/PagesControllerTests.cs
+++ b/src/web/tests/CareLeavers.Web.Tests/Controllers/PagesControllerTests.cs
@@ -232,6 +232,45 @@ public class PagesControllerTests
         _httpContext.Response.Cookies.Received(1).Append("consent-cookie", "no", Arg.Any<CookieOptions>());
     }
 
+    [Test]
+    public async Task TranslationLimitReached_With_LanguageCode_Returns_View()
+    {
+        Page page = new Page { Title = "Translation Limit Reached Page" };
+        _contentService.GetPage("translation-limit-reached").Returns(page);
+
+        IActionResult result = await _pagesController.TranslationLimitReached("en");
+        
+        Assert.That(result, Is.TypeOf<ViewResult>());
+        ViewResult? viewResult = result as ViewResult;
+        Assert.That(viewResult, Is.Not.Null);
+        Assert.That(viewResult.Model, Is.EqualTo(page));
+    }
+    
+    [Test]
+    public async Task TranslationLimitReached_Without_LanguageCode_Returns_View()
+    {
+        Page page = new Page { Title = "Translation Limit Reached Page" };
+        _contentService.GetPage("translation-limit-reached").Returns(page);
+
+        IActionResult result = await _pagesController.TranslationLimitReached(null);
+        
+        Assert.That(result, Is.TypeOf<ViewResult>());
+        ViewResult? viewResult = result as ViewResult;
+        Assert.That(viewResult, Is.Not.Null);
+        Assert.That(viewResult.Model, Is.EqualTo(page));
+    }
+    
+    [Test]
+    public async Task TranslationLimitReached_If_PageDoesNotExistInCms_Returns_NotFound()
+    {
+        Page? page = null;
+        _contentService.GetPage("translation-limit-reached").Returns(page);
+
+        IActionResult result = await _pagesController.TranslationLimitReached(null);
+        
+        Assert.That(result, Is.TypeOf<NotFoundResult>());
+    }
+
     [TearDown]
     public void Teardown()
     {

--- a/src/web/tests/CareLeavers.Web.Tests/Controllers/PrintControllerTests.cs
+++ b/src/web/tests/CareLeavers.Web.Tests/Controllers/PrintControllerTests.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using CareLeavers.Web.CircuitBreaker;
 using CareLeavers.Web.Configuration;
 using CareLeavers.Web.Contentful;
@@ -6,7 +7,9 @@ using CareLeavers.Web.Models.Content;
 using CareLeavers.Web.Translation;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
 using Microsoft.AspNetCore.Mvc.Routing;
+using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
@@ -41,6 +44,16 @@ public class PrintControllerTests
         _httpContextAccessor = Substitute.For<IHttpContextAccessor>();
         _httpContextAccessor.HttpContext = new DefaultHttpContext();
         _httpContextAccessor.HttpContext.Session = new MockSession();
+
+        ActionContext actionContext = new ActionContext
+        {
+            HttpContext = _httpContextAccessor.HttpContext,
+            RouteData = new RouteData(),
+            ActionDescriptor = new ActionDescriptor()
+        };
+        
+        _urlHelper.ActionContext.Returns(actionContext);
+        
         _circuitBreakerOptions = Options.Create(new CircuitBreakerOptions { PdfGeneratorLimit = int.MaxValue });
 
         _circuitBreakerService = new CircuitBreakerService(_httpContextAccessor, _circuitBreakerOptions);
@@ -247,6 +260,44 @@ public class PrintControllerTests
         IActionResult result = await _printController.DownloadPdf(_circuitBreakerService, id, languageCode);
         
         Assert.That(result, Is.TypeOf<NotFoundResult>());
+    }
+    
+    [Test]
+    public async Task DownloadPdf_WhenCircuitIsNotBroken_Continues_In_Factory()
+    {
+        const string id = "test-id";
+        const string languageCode = "en";
+        PrintableCollection collection = new PrintableCollection { Title = "Test", Identifier = id };
+        _contentService.GetPrintableCollection(id).Returns(collection);
+        _contentService.GetConfiguration().Returns(new ContentfulConfigurationEntity());
+        
+        _httpContextAccessor.HttpContext?.Session.SetInt32(CircuitBreakerOptions.PdfGeneratorKey, 0);
+
+        _urlHelper.Action(Arg.Any<UrlActionContext>()).Returns("https://localhost:1234");
+        
+        MockHttpMessageHandler handler = new();
+        handler.StatusCode = HttpStatusCode.OK;
+        handler.Content = new ByteArrayContent([1, 2, 3]);
+        _httpClientFactory.CreateClient().Returns(new HttpClient(handler));
+        
+        _fusionCache.GetOrSetAsync(
+            Arg.Any<string>(),
+            Arg.Any<Func<FusionCacheFactoryExecutionContext<byte[]>, CancellationToken, Task<byte[]>>>(),
+            Arg.Any<MaybeValue<byte[]>>(),
+            Arg.Any<FusionCacheEntryOptions>(),
+            Arg.Any<IEnumerable<string>>(),
+            Arg.Any<CancellationToken>()
+        ).Returns((Func<NSubstitute.Core.CallInfo, ValueTask<byte[]>>)(callInfo => {
+            var factory = callInfo.ArgAt<Func<FusionCacheFactoryExecutionContext<byte[]>, CancellationToken, Task<byte[]>>>(1);
+            return new ValueTask<byte[]>(factory(null!, CancellationToken.None));
+        }));
+
+        IActionResult result = await _printController.DownloadPdf(_circuitBreakerService, id, languageCode);
+        
+        Assert.That(result, Is.TypeOf<FileContentResult>());
+        FileContentResult? fileResult = result as FileContentResult;
+        Assert.That(fileResult, Is.Not.Null);
+        Assert.That(fileResult.FileContents, Is.EqualTo(new byte[] { 1, 2, 3 }));
     }
 
     [TearDown]

--- a/src/web/tests/CareLeavers.Web.Tests/Controllers/PrintControllerTests.cs
+++ b/src/web/tests/CareLeavers.Web.Tests/Controllers/PrintControllerTests.cs
@@ -231,7 +231,7 @@ public class PrintControllerTests
         _circuitBreakerOptions.Value.PdfGeneratorLimit = 1;
         
         _httpContextAccessor.HttpContext?.Session.SetInt32(CircuitBreakerOptions.PdfGeneratorKey, 2);
-
+        
         _fusionCache.GetOrSetAsync(
             Arg.Any<string>(),
             Arg.Any<Func<FusionCacheFactoryExecutionContext<byte[]>, CancellationToken, Task<byte[]>>>(),
@@ -239,7 +239,10 @@ public class PrintControllerTests
             Arg.Any<FusionCacheEntryOptions>(),
             Arg.Any<IEnumerable<string>>(),
             Arg.Any<CancellationToken>()
-        ).Returns([]);
+        ).Returns((Func<NSubstitute.Core.CallInfo, ValueTask<byte[]>>)(callInfo => {
+            var factory = callInfo.ArgAt<Func<FusionCacheFactoryExecutionContext<byte[]>, CancellationToken, Task<byte[]>>>(1);
+            return new ValueTask<byte[]>(factory(null!, CancellationToken.None));
+        }));
 
         IActionResult result = await _printController.DownloadPdf(_circuitBreakerService, id, languageCode);
         

--- a/src/web/tests/CareLeavers.Web.Tests/Controllers/PrintControllerTests.cs
+++ b/src/web/tests/CareLeavers.Web.Tests/Controllers/PrintControllerTests.cs
@@ -1,3 +1,4 @@
+using CareLeavers.Web.CircuitBreaker;
 using CareLeavers.Web.Configuration;
 using CareLeavers.Web.Contentful;
 using CareLeavers.Web.Controllers;
@@ -21,8 +22,11 @@ public class PrintControllerTests
     private IOptions<PdfGenerationOptions> _options;
     private IFusionCache _fusionCache;
     private IUrlHelper _urlHelper;
+    private IHttpContextAccessor _httpContextAccessor;
+    private IOptions<CircuitBreakerOptions> _circuitBreakerOptions;
 
     private PrintController _printController;
+    private CircuitBreakerService _circuitBreakerService;
 
     [SetUp]
     public void Init()
@@ -33,6 +37,13 @@ public class PrintControllerTests
         _options = Options.Create(new PdfGenerationOptions { ApiKey = "test-key", Sandbox = true });
         _fusionCache = Substitute.For<IFusionCache>();
         _urlHelper = Substitute.For<IUrlHelper>();
+        
+        _httpContextAccessor = Substitute.For<IHttpContextAccessor>();
+        _httpContextAccessor.HttpContext = new DefaultHttpContext();
+        _httpContextAccessor.HttpContext.Session = new MockSession();
+        _circuitBreakerOptions = Options.Create(new CircuitBreakerOptions { PdfGeneratorLimit = int.MaxValue });
+
+        _circuitBreakerService = new CircuitBreakerService(_httpContextAccessor, _circuitBreakerOptions);
 
         _printController = new PrintController(_httpClientFactory, _contentService, _translationService, _options,
             _fusionCache)
@@ -40,7 +51,7 @@ public class PrintControllerTests
             Url = _urlHelper,
             ControllerContext = new ControllerContext
             {
-                HttpContext = new DefaultHttpContext()
+                HttpContext = _httpContextAccessor.HttpContext
             }
         };
     }
@@ -134,7 +145,7 @@ public class PrintControllerTests
             Arg.Any<CancellationToken>()
         ).Returns(pdfBytes);
 
-        IActionResult result = await _printController.DownloadPdf(id, "en");
+        IActionResult result = await _printController.DownloadPdf(_circuitBreakerService, id, "en");
         
         Assert.That(result, Is.TypeOf<FileContentResult>());
         FileContentResult? fileContent = result as FileContentResult;
@@ -167,7 +178,7 @@ public class PrintControllerTests
             Arg.Any<CancellationToken>()
         ).Returns(pdfBytes);
 
-        IActionResult result = await _printController.DownloadPdf(id, languageCode);
+        IActionResult result = await _printController.DownloadPdf(_circuitBreakerService, id, languageCode);
         
         Assert.That(result, Is.TypeOf<FileContentResult>());
         string? contentDispositionHeader = _printController.Response.Headers.ContentDisposition;
@@ -192,7 +203,7 @@ public class PrintControllerTests
             Arg.Any<CancellationToken>()
         ).ThrowsAsync(new HttpRequestException());
         
-        IActionResult result = await _printController.DownloadPdf(id, languageCode);
+        IActionResult result = await _printController.DownloadPdf(_circuitBreakerService, id, languageCode);
         
         Assert.That(result, Is.TypeOf<RedirectToActionResult>());
         RedirectToActionResult? redirectResult = result as RedirectToActionResult;
@@ -208,6 +219,31 @@ public class PrintControllerTests
             Assert.That(redirectResult.RouteValues["identifier"], Is.EqualTo(id));
             Assert.That(redirectResult.RouteValues["languageCode"], Is.EqualTo(languageCode));
         }
+    }
+
+    [Test]
+    public async Task DownloadPdf_WhenCircuitIsBroken_Returns_NotFound()
+    {
+        const string id = "test-id";
+        const string languageCode = "en";
+        PrintableCollection collection = new PrintableCollection { Title = "Test", Identifier = id };
+        _contentService.GetPrintableCollection(id).Returns(collection);
+        _circuitBreakerOptions.Value.PdfGeneratorLimit = 1;
+        
+        _httpContextAccessor.HttpContext?.Session.SetInt32(CircuitBreakerOptions.PdfGeneratorKey, 2);
+
+        _fusionCache.GetOrSetAsync(
+            Arg.Any<string>(),
+            Arg.Any<Func<FusionCacheFactoryExecutionContext<byte[]>, CancellationToken, Task<byte[]>>>(),
+            Arg.Any<MaybeValue<byte[]>>(),
+            Arg.Any<FusionCacheEntryOptions>(),
+            Arg.Any<IEnumerable<string>>(),
+            Arg.Any<CancellationToken>()
+        ).Returns([]);
+
+        IActionResult result = await _printController.DownloadPdf(_circuitBreakerService, id, languageCode);
+        
+        Assert.That(result, Is.TypeOf<NotFoundResult>());
     }
 
     [TearDown]

--- a/src/web/tests/CareLeavers.Web.Tests/Filters/TranslationAttributeTests.cs
+++ b/src/web/tests/CareLeavers.Web.Tests/Filters/TranslationAttributeTests.cs
@@ -1,4 +1,6 @@
 using System.Text;
+using System.Text.Json;
+using CareLeavers.Web.CircuitBreaker;
 using CareLeavers.Web.Configuration;
 using CareLeavers.Web.Filters;
 using CareLeavers.Web.Models.Content;
@@ -9,6 +11,7 @@ using Microsoft.AspNetCore.Mvc.Abstractions;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using NSubstitute;
 using ZiggyCreatures.Caching.Fusion;
 
@@ -16,12 +19,15 @@ namespace CareLeavers.Web.Tests.Filters;
 
 public class TranslationAttributeTests
 {
+    private IHttpContextAccessor _httpContextAccessor;
+    private HttpContext _httpContext;
+    private IOptions<CircuitBreakerOptions> _circuitBreakerOptions;
+    
     private IFusionCache _fusionCache;
     private ITranslationService _translationService;
+    private CircuitBreakerService _circuitBreakerService;
     private IContentfulConfiguration _contentfulConfiguration;
-
-    private HttpContext _httpContext;
-
+    
     private ActionExecutingContext _actionExecutingContext;
     private ResultExecutingContext _resultExecutingContext;
 
@@ -34,13 +40,22 @@ public class TranslationAttributeTests
         _translationService = Substitute.For<ITranslationService>();
         _contentfulConfiguration = Substitute.For<IContentfulConfiguration>();
 
+        _httpContextAccessor = Substitute.For<IHttpContextAccessor>();
+        _httpContextAccessor.HttpContext = new DefaultHttpContext();
+        _httpContextAccessor.HttpContext.Session = new MockSession();
+        _circuitBreakerOptions = Options.Create(new CircuitBreakerOptions { AzureTranslationLimit = int.MaxValue });
+        
+        _circuitBreakerService = new CircuitBreakerService(_httpContextAccessor, _circuitBreakerOptions);
+
         ServiceCollection serviceCollection = [];
         serviceCollection.AddSingleton(_fusionCache);
         serviceCollection.AddSingleton(_translationService);
+        serviceCollection.AddSingleton(_circuitBreakerService);
         serviceCollection.AddSingleton(_contentfulConfiguration);
         ServiceProvider serviceProvider = serviceCollection.BuildServiceProvider();
 
-        _httpContext = new DefaultHttpContext { RequestServices = serviceProvider };
+        _httpContextAccessor.HttpContext.RequestServices = serviceProvider;
+        _httpContext = _httpContextAccessor.HttpContext;
 
         ActionContext actionContext = new ActionContext(_httpContext, new RouteData(), new ActionDescriptor());
 
@@ -154,6 +169,7 @@ public class TranslationAttributeTests
             Assert.That(nextCalled, Is.False);
             Assert.That(_actionExecutingContext.Result, Is.TypeOf<ContentResult>());
         }
+
         ContentResult? contentResult = (ContentResult)_actionExecutingContext.Result;
         Assert.That(contentResult.Content, Is.Not.Null);
         using (Assert.EnterMultipleScope())
@@ -192,6 +208,7 @@ public class TranslationAttributeTests
             Assert.That(nextCalled, Is.True);
             Assert.That(_httpContext.Response.Body, Is.Not.SameAs(originalBody));
         }
+
         Assert.That(_httpContext.Response.Body, Is.TypeOf<MemoryStream>());
 
         return;
@@ -243,6 +260,40 @@ public class TranslationAttributeTests
 
         Task<ActionExecutedContext> Next() =>
             Task.FromResult(new ActionExecutedContext(_actionExecutingContext, [], Substitute.For<Controller>()));
+    }
+
+    [Test]
+    public async Task OnActionExecutionAsync_WhenCircuitIsBroke_Returns_TranslationLimitReachedPage()
+    {
+        _contentfulConfiguration.GetConfiguration()
+            .Returns(new ContentfulConfigurationEntity { TranslationEnabled = true });
+        _translationService.GetLanguages().Returns(new List<TranslationLanguage> { new() { Code = "sv" } });
+        _actionExecutingContext.RouteData.Values["slug"] = "test-slug";
+        _actionExecutingContext.RouteData.Values["languageCode"] = "sv";
+        _httpContext.Request.RouteValues["languageCode"] = "sv";
+        _circuitBreakerOptions.Value.AzureTranslationLimit = 1;
+        bool nextCalled = false;
+
+        List<string> translatedLanguages = ["Test", "Test"];
+        _httpContext.Session.SetString(CircuitBreakerOptions.AzureTranslationKey, 
+            JsonSerializer.Serialize(translatedLanguages, new JsonSerializerOptions(JsonSerializerDefaults.Web)));
+
+        await _translationAttribute.OnActionExecutionAsync(_actionExecutingContext, Next);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(nextCalled, Is.False);
+            Assert.That(_actionExecutingContext.Result, Is.TypeOf<RedirectToActionResult>());
+        }
+
+        return;
+
+        Task<ActionExecutedContext> Next()
+        {
+            nextCalled = true;
+            return Task.FromResult(new ActionExecutedContext(_actionExecutingContext, [],
+                Substitute.For<Controller>()));
+        }
     }
 
     [Test]
@@ -301,10 +352,11 @@ public class TranslationAttributeTests
         };
 
         _fusionCache.TryGetAsync<byte[]?>("collection:test-identifier:language:sv").Returns(MaybeValue<byte[]?>.None);
-        _fusionCache.TryGetAsync<PrintableCollection>("collection:test-identifier").Returns(MaybeValue<PrintableCollection>.FromValue(collection));
-        
+        _fusionCache.TryGetAsync<PrintableCollection>("collection:test-identifier")
+            .Returns(MaybeValue<PrintableCollection>.FromValue(collection));
+
         await _translationAttribute.OnActionExecutionAsync(_actionExecutingContext, Next);
-        
+
         await _translationAttribute.OnResultExecutionAsync(_resultExecutingContext, ResultNext);
 
         await _fusionCache.Received(1).SetAsync(
@@ -312,7 +364,7 @@ public class TranslationAttributeTests
             Arg.Any<byte[]>(),
             Arg.Any<FusionCacheEntryOptions>(),
             Arg.Is<IEnumerable<string>>(tags => tags.Contains("page-one") && tags.Contains("page-two"))
-            );
+        );
 
         return;
 

--- a/src/web/tests/CareLeavers.Web.Tests/Filters/TranslationAttributeTests.cs
+++ b/src/web/tests/CareLeavers.Web.Tests/Filters/TranslationAttributeTests.cs
@@ -19,6 +19,8 @@ namespace CareLeavers.Web.Tests.Filters;
 
 public class TranslationAttributeTests
 {
+    private static readonly JsonSerializerOptions JsonSerializerOptions = new(JsonSerializerDefaults.Web);
+    
     private IHttpContextAccessor _httpContextAccessor;
     private HttpContext _httpContext;
     private IOptions<CircuitBreakerOptions> _circuitBreakerOptions;
@@ -276,7 +278,7 @@ public class TranslationAttributeTests
 
         List<string> translatedLanguages = ["Test", "Test"];
         _httpContext.Session.SetString(CircuitBreakerOptions.AzureTranslationKey, 
-            JsonSerializer.Serialize(translatedLanguages, new JsonSerializerOptions(JsonSerializerDefaults.Web)));
+            JsonSerializer.Serialize(translatedLanguages, JsonSerializerOptions));
 
         await _translationAttribute.OnActionExecutionAsync(_actionExecutingContext, Next);
 

--- a/src/web/tests/CareLeavers.Web.Tests/MockSession.cs
+++ b/src/web/tests/CareLeavers.Web.Tests/MockSession.cs
@@ -1,0 +1,26 @@
+using Microsoft.AspNetCore.Http;
+using System.Diagnostics.CodeAnalysis;
+
+namespace CareLeavers.Web.Tests;
+
+public sealed class MockSession : ISession
+{
+    private readonly Dictionary<string, byte[]> _sessionStorage = new();
+
+    public Task LoadAsync(CancellationToken cancellationToken = new()) => Task.CompletedTask;
+
+    public Task CommitAsync(CancellationToken cancellationToken = new()) => Task.CompletedTask;
+
+    public bool TryGetValue(string key, [NotNullWhen(true)] out byte[]? value) =>
+        _sessionStorage.TryGetValue(key, out value);
+
+    public void Set(string key, byte[] value) => _sessionStorage[key] = value;
+
+    public void Remove(string key) => _sessionStorage.Remove(key);
+
+    public void Clear() => _sessionStorage.Clear();
+
+    public bool IsAvailable => true;
+    public string Id { get; } = Guid.NewGuid().ToString();
+    public IEnumerable<string> Keys => _sessionStorage.Keys;
+}


### PR DESCRIPTION
Ticket: [CL-340](https://dfedigital.atlassian.net/browse/CL-340)
Ticket: [CL-343](https://dfedigital.atlassian.net/browse/CL-343)

BREAKING CHANGE: Because now users (and technically external tools) are now limited on how many times they can use the translation and PDF generator features of our site, I've considered this to be a breaking change

This PR:

- Implements a circuit breaker for the AI translate - Maximum of 5 unique languages allowed per user per day, re-selecting a previously selected language doesn't count towards the limit, navigating through the site normally in another language doesn't count towards the limit
- Implements a circuit breaker for the PDF generator - Maximum of 10 generations per user per day, doesn't count if the PDF is cached (either from the same or another user using the feature previously)
- Limits are configurable via appsettings, can be Terraformed in if wanted
- Adds custom error page for if the user has reached their translation limit
- Updates cookie page (including on Contentful) to let users know about new Session cookie usage