### PR TITLE
Add missing PAL metadata to deployment

### DIFF
--- a/.github/workflows/deploy-env.yaml
+++ b/.github/workflows/deploy-env.yaml
@@ -101,6 +101,12 @@ jobs:
                 "subscriptionId": "${{ secrets.AZURE_SUBSCRIPTION_ID }}"
             }
 
+      # Ensure PAL metadata is set on the deployment principal
+      - name: Service principal metadata
+        continue-on-error: true
+        run: |
+          az rest --method put --uri "https://management.azure.com/providers/microsoft.managementpartner/partners/6084223?api-version=2018-02-01" --body '{"partnerId": "6084223"}' || true
+
       - name: Add Alert Management Provider
         run: |
           az provider register --namespace Microsoft.AlertsManagement


### PR DESCRIPTION
I've had a chat with some Microsoft account folks, and they recommended setting the PAL link on service principals, to ensure that their credit monitoring is working correctly.

The deployment user should have an association with the management partner number, as subscription-level identifiers are no longer used. This enables Microsoft's tracking to differentiate between solutions partners. Per https://learn.microsoft.com/en-us/azure/cost-management-billing/manage/link-partner-id this does not impact any access change behaviour of the services, it is purely to support Microsoft's metrics.