### PR TITLE
feat(CL-421): Checker Button

### DIFF
--- a/src/contentful/CareLeavers.ContentfulMigration/Migrations/0065-add-button-to-rich-content.cjs
+++ b/src/contentful/CareLeavers.ContentfulMigration/Migrations/0065-add-button-to-rich-content.cjs
@@ -1,0 +1,63 @@
+module.exports = function (migration) {
+    const richContent = migration
+        .editContentType("richContent")
+
+    richContent
+        .editField("content")
+        .validations([
+            {
+                enabledMarks: [
+                    "bold",
+                    "italic"
+                ]
+            },
+            {
+                enabledNodeTypes: [
+                    "heading-2",
+                    "heading-3",
+                    "heading-4",
+                    "ordered-list",
+                    "unordered-list",
+                    "embedded-entry-block",
+                    "embedded-asset-block",
+                    "entry-hyperlink",
+                    "hyperlink",
+                    "embedded-entry-inline",
+                    "hr",
+                    "table"
+                ],
+                message: "Only heading 3, heading 4, ordered list, unordered list, block entry, asset, link to entry, link to Url, inline entry, table, and horizontal rule nodes are allowed"
+            },
+            {
+                nodes: {
+                    "embedded-entry-block": [
+                        {
+                            "linkContentType": [
+                                "callToAction",
+                                "grid",
+                                "definitionContent",
+                                "button"
+                            ],
+                            "message": null
+                        }
+                    ],
+                    "embedded-entry-inline": [
+                        {
+                            "linkContentType": [
+                                "definitionLink"
+                            ],
+                            "message": null
+                        }
+                    ],
+                    "entry-hyperlink": [
+                        {
+                            "linkContentType": [
+                                "page"
+                            ],
+                            "message": null
+                        }
+                    ]
+                }
+            }
+        ]);
+}


### PR DESCRIPTION
Ticket: [CL-421](https://dfedigital.atlassian.net/browse/CL-421)

Small PR supporting Contentful change to add a checker button to the home page, but this means allowing buttons to be embedded in rich content. The code itself already renders the buttons correctly (pre-tested), so only a migration needs to be recorded.