### PR TITLE
refactor(CL-434): Dockerfile

### DIFF
--- a/.github/workflows/validate-e2e.yaml
+++ b/.github/workflows/validate-e2e.yaml
@@ -28,6 +28,14 @@ jobs:
                 
       - name: Lowercase the repo name and username
         run: echo "REPO=${GITHUB_REPOSITORY,,}" >>${GITHUB_ENV}
+        
+      - name: Create Local Developer Certificate
+        run: |
+          mkdir -p ${HOME}/.aspnet/https
+          export SSL_CERT_DIR="$HOME/.aspnet/dev-certs/trust:$SSL_CERT_DIR"
+          dotnet dev-certs https -ep ${HOME}/.aspnet/https/aspnetapp.pfx -p "e2e"
+          dotnet dev-certs https --trust
+          chmod -R 755 ${HOME}/.aspnet
 
       - name: Build Web Docker Image
         id: build
@@ -38,11 +46,12 @@ jobs:
         id: run
         if: steps.build.outcome == 'success'
         working-directory: ./src
+        run: |
+          docker compose -f infrastructure/docker/docker-compose-ci.yml up -d
         env:
           CONTENTFUL_DELIVERY_API_KEY: ${{ secrets.CONTENTFUL_DELIVERY_API_KEY }}
           CONTENTFUL_PREVIEW_API_KEY: ${{ secrets.CONTENTFUL_PREVIEW_API_KEY }}
           CONTENTFUL_SPACE_ID: ${{ secrets.CONTENTFUL_SPACE_ID }}
-        run: docker compose -f infrastructure/docker/docker-compose-ci.yml up -d
 
       - name: Install dependencies
         working-directory: ./src/e2e/CareLeavers.E2ETests

--- a/src/.dockerignore
+++ b/src/.dockerignore
@@ -12,6 +12,7 @@
 **/*.dbmdl
 **/*.jfm
 **/azds.yaml
+**/wwwroot
 **/bin
 **/charts
 **/docker-compose*

--- a/src/infrastructure/docker/docker-compose-ci.yml
+++ b/src/infrastructure/docker/docker-compose-ci.yml
@@ -14,4 +14,6 @@ services:
       - Rebrand=true
       - ASPNETCORE_URLS=https://+:8080
       - ASPNETCORE_Kestrel__Certificates__Default__Password=e2e
-      - ASPNETCORE_Kestrel__Certificates__Default__Path=/app/aspnetapp.pfx
+      - ASPNETCORE_Kestrel__Certificates__Default__Path=/https/aspnetapp.pfx
+    volumes:
+      - ~/.aspnet/https:/https:ro

--- a/src/web/CareLeavers.Web/Dockerfile
+++ b/src/web/CareLeavers.Web/Dockerfile
@@ -1,28 +1,44 @@
-﻿FROM alpine:latest AS security_provider
-RUN addgroup -S nonroot && adduser -S nonroot -G nonroot
-
-FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+﻿# -- Build Node -- #
+#    Image - [Major]-alpine[Major].[Minor] - E.g., 26-alpine3.23
+FROM node@sha256:144769ec3f32e8ee36b3cfde91e82bee25d9367b20f31a151f3f7eea3a2a8541 AS build-node
 WORKDIR /src
-COPY web/CareLeavers.Web .
-RUN dotnet publish "CareLeavers.Web.csproj" -c Release -o /app/out --sc false
-RUN mkdir /app/https
-RUN dotnet dev-certs https -ep /app/https/aspnetapp.pfx -p e2e
 
-FROM node:20 AS node
-WORKDIR /src
-COPY "web/CareLeavers.Web/package.json" "web/CareLeavers.Web/yarn.lock" "web/CareLeavers.Web/Gulpfile.js" ./
-COPY "web/CareLeavers.Web/AssetSrc/" "AssetSrc/"
+RUN npm install --ignore-scripts --global corepack@0.35.0
+RUN npm install --ignore-scripts --global gulp-cli@3.1.0
+
+COPY ["web/CareLeavers.Web/package.json", "."]
+COPY ["web/CareLeavers.Web/yarn.lock", "."]
 RUN yarn install --ignore-scripts
-RUN npm install --ignore-scripts -g gulp
-RUN gulp dev
 
-FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS final
-WORKDIR /app
-COPY --from=security_provider /etc/passwd /etc/passwd
-COPY --from=build /app/out .
-COPY --from=node /src/wwwroot ./wwwroot
-USER nonroot
-COPY --chmod=0755 --chown=nonroot --from=build /app/https .
-ENTRYPOINT ["dotnet", "CareLeavers.Web.dll"]
+COPY ["web/CareLeavers.Web/Gulpfile.js", "."]
+COPY ["web/CareLeavers.Web/AssetSrc/", "./AssetSrc/"]
+RUN gulp dev
+# -- Build Node -- #
+
+# -- Build .NET -- #
+#    Image - [Major].[Minor].[Patch]-alpine[Major].[Minor] - E.g., 8.0.422-alpine3.23
+FROM mcr.microsoft.com/dotnet/sdk@sha256:d9f4f4a5d99a43799b500ee1365c370e3233822fbe7d43666715d9b5b5cda2ab AS build-dotnet
+WORKDIR /src
+
+COPY ["web/CareLeavers.Web/CareLeavers.Web.csproj", "."]
+COPY ["web/CareLeavers.Web/packages.lock.json", "."]
+RUN dotnet restore CareLeavers.Web.csproj --use-lock-file
+
+COPY ["web/CareLeavers.Web", "."]
+RUN dotnet publish CareLeavers.Web.csproj --no-restore --configuration Release --output ./publish
+# -- Build .NET -- #
+
+# -- Run .NET -- #
+#    Image - [Major].[Minor].[Patch]-alpine[Major].[Minor] - E.g., 8.0.28-alpine3.23
+FROM mcr.microsoft.com/dotnet/aspnet@sha256:4718c6b44771e710f91d6129912cb4fa3b90024ec4e23b3f8ce89822fba612fd
+RUN apk add --no-cache icu-libs && apk add --no-cache icu-data-full
+ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false
+USER app
+WORKDIR /src
+
+COPY --from=build-node ["src/wwwroot", "./wwwroot/"]
+COPY --from=build-dotnet ["src/publish", "."]
+
 EXPOSE 8080
 EXPOSE 8081
+ENTRYPOINT ["dotnet", "CareLeavers.Web.dll"]

--- a/src/web/CareLeavers.Web/Dockerfile
+++ b/src/web/CareLeavers.Web/Dockerfile
@@ -1,5 +1,5 @@
 ﻿# -- Build Node -- #
-#    Image - [Major]-alpine[Major].[Minor] - E.g., 26-alpine3.23
+#    Image: Node 26 Alpine
 FROM node@sha256:144769ec3f32e8ee36b3cfde91e82bee25d9367b20f31a151f3f7eea3a2a8541 AS build-node
 WORKDIR /src
 
@@ -16,7 +16,7 @@ RUN gulp dev
 # -- Build Node -- #
 
 # -- Build .NET -- #
-#    Image - [Major].[Minor].[Patch]-alpine[Major].[Minor] - E.g., 8.0.422-alpine3.23
+#    Image: .NET 8 Alpine
 FROM mcr.microsoft.com/dotnet/sdk@sha256:d9f4f4a5d99a43799b500ee1365c370e3233822fbe7d43666715d9b5b5cda2ab AS build-dotnet
 WORKDIR /src
 
@@ -29,7 +29,7 @@ RUN dotnet publish CareLeavers.Web.csproj --no-restore --configuration Release -
 # -- Build .NET -- #
 
 # -- Run .NET -- #
-#    Image - [Major].[Minor].[Patch]-alpine[Major].[Minor] - E.g., 8.0.28-alpine3.23
+#    Image: .NET 8 Alpine
 FROM mcr.microsoft.com/dotnet/aspnet@sha256:4718c6b44771e710f91d6129912cb4fa3b90024ec4e23b3f8ce89822fba612fd
 RUN apk add --no-cache icu-libs icu-data-full tzdata
 ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false

--- a/src/web/CareLeavers.Web/Dockerfile
+++ b/src/web/CareLeavers.Web/Dockerfile
@@ -31,7 +31,7 @@ RUN dotnet publish CareLeavers.Web.csproj --no-restore --configuration Release -
 # -- Run .NET -- #
 #    Image - [Major].[Minor].[Patch]-alpine[Major].[Minor] - E.g., 8.0.28-alpine3.23
 FROM mcr.microsoft.com/dotnet/aspnet@sha256:4718c6b44771e710f91d6129912cb4fa3b90024ec4e23b3f8ce89822fba612fd
-RUN apk add --no-cache icu-libs && apk add --no-cache icu-data-full
+RUN apk add --no-cache icu-libs icu-data-full tzdata
 ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false
 USER app
 WORKDIR /src


### PR DESCRIPTION
Ticket: [CL-434](https://dfedigital.atlassian.net/browse/CL-434)

This PR does the following:

- All images (Node, .NET SDK, .NET Runtime) are now Alpine based, this is a very lightweight distro designed for security

- Versions are all pinned with their SHA256 digests (with a helpful comment to map it to the image I used), decreases supply chain attack risk

- .NET Alpine gives us a user named "app" which is non-root by default, so we can just use that instead of copying /etc/passwd and such

- Removes the local dev-certs stuff from the Dockerfile - Microsoft explicitly recommends not doing this for Production deployments. These are only used for running the E2E tests, so the E2E workflow now handles the dev-certs rather than the Dockerfile.

- Installs `icu-libs`, `icu-data-full`, `tzdata` - .NET uses system localisation libraries and Alpine is so lightweight it doesn't install them OOTB, so we add them for the app

- Uses Node 26 for building the frontend, it's defaulting to becoming the LTS release in October so may as well get ahead of the curve

- Layers - build stages (npm install & gulp dev, dotnet restore & dotnet publish) are split, so now Docker is more likely to reuse layers if files are unchanged (e.g., a code change but not a package version change will re-use the layer created by dotnet restore)

