### PR TITLE
ci: Ignore Major Versions on Azure NuGet Packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -55,6 +55,8 @@ updates:
     ignore:
       - dependency-name: "Microsoft.*"
         update-types: ["version-update:semver-major"]
+      - dependency-name: "Azure.*"
+        update-types: [ "version-update:semver-major" ]
       - dependency-name: "Serilog.AspNetCore"
         update-types: [ "version-update:semver-major" ]
     groups:


### PR DESCRIPTION
A Dependabot PR updated `Azure.AI.Translation.Text` from `1.0.0` to `2.0.0`, which appears to be a buggy release even after adapting to the breaking changes (no documentation by the way!)

Since the Dependabot already ignores major versions on `Microsoft.*`, we thought it'd be sensible to do the same for anything `Azure.*`