### PR TITLE
fix(Dependabot): Empty Ignore Clause

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,7 +37,6 @@ updates:
     commit-message:
       prefix: "[docker] "
     open-pull-requests-limit: 5
-    ignore:
     groups:
       docker-deps:
         patterns:


### PR DESCRIPTION
When copy pasting a block to add Docker to Dependabot I accidentally left an `ignore:` in that's empty, sneaky!