### PR TITLE
fix(CL-434): Dockerfile Versioning

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,6 +37,13 @@ updates:
     commit-message:
       prefix: "[docker] "
     open-pull-requests-limit: 5
+    ignore:
+      - dependency-name: "node"
+        update-types: [ "version-update:semver-major" ]
+      - dependency-name: "mcr.microsoft.com/dotnet/sdk"
+        update-types: [ "version-update:semver-major" ]
+      - dependency-name: "mcr.microsoft.com/dotnet/aspnet"
+        update-types: [ "version-update:semver-major" ]
     groups:
       docker-deps:
         patterns:

--- a/src/web/CareLeavers.Web/Dockerfile
+++ b/src/web/CareLeavers.Web/Dockerfile
@@ -1,6 +1,5 @@
 ﻿# -- Build Node -- #
-#    Image: Node 26 Alpine
-FROM node@sha256:144769ec3f32e8ee36b3cfde91e82bee25d9367b20f31a151f3f7eea3a2a8541 AS build-node
+FROM node:26-alpine@sha256:144769ec3f32e8ee36b3cfde91e82bee25d9367b20f31a151f3f7eea3a2a8541 AS build-node
 WORKDIR /src
 
 RUN npm install --ignore-scripts --global corepack@0.35.0
@@ -16,8 +15,7 @@ RUN gulp dev
 # -- Build Node -- #
 
 # -- Build .NET -- #
-#    Image: .NET 8 Alpine
-FROM mcr.microsoft.com/dotnet/sdk@sha256:d9f4f4a5d99a43799b500ee1365c370e3233822fbe7d43666715d9b5b5cda2ab AS build-dotnet
+FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine@sha256:d9f4f4a5d99a43799b500ee1365c370e3233822fbe7d43666715d9b5b5cda2ab AS build-dotnet
 WORKDIR /src
 
 COPY ["web/CareLeavers.Web/CareLeavers.Web.csproj", "."]
@@ -29,8 +27,7 @@ RUN dotnet publish CareLeavers.Web.csproj --no-restore --configuration Release -
 # -- Build .NET -- #
 
 # -- Run .NET -- #
-#    Image: .NET 8 Alpine
-FROM mcr.microsoft.com/dotnet/aspnet@sha256:4718c6b44771e710f91d6129912cb4fa3b90024ec4e23b3f8ce89822fba612fd
+FROM mcr.microsoft.com/dotnet/aspnet:8.0-alpine@sha256:4718c6b44771e710f91d6129912cb4fa3b90024ec4e23b3f8ce89822fba612fd
 RUN apk add --no-cache icu-libs icu-data-full tzdata
 ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false
 USER app


### PR DESCRIPTION
Ticket: [CL-434](https://dfedigital.atlassian.net/browse/CL-434)

Adds an image back in to the FROM blocks, so that way Dependabot knows what images to search for when it updates digests (also means I can remove the comment?)

Since the SHA256 digest is still there, the image is still immutable. It just means that it **_should_** only update to other .NET 8 Alpine / Node 26 Alpine images in future (unless we explicitly update to .NET 10 or whatevs)