### PR TITLE
ci(CL-467): Static Analysis (Permissions)

### DIFF
--- a/.github/workflows/deploy-contentful-migrations.yml
+++ b/.github/workflows/deploy-contentful-migrations.yml
@@ -17,6 +17,8 @@ on:
           - production
           - e2e
 
+permissions: {}
+
 jobs:
   contentful:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-contentful-migrations.yml
+++ b/.github/workflows/deploy-contentful-migrations.yml
@@ -25,6 +25,8 @@ jobs:
     name: Run Contentful Migrations
     steps:
       - uses: actions/checkout@v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Set Node.js 20.x
         uses: actions/setup-node@v6

--- a/.github/workflows/deploy-env.yaml
+++ b/.github/workflows/deploy-env.yaml
@@ -18,6 +18,8 @@ on:
           - "elz-staging"
           - "elz-production"
 
+permissions: {}
+
 run-name: ${{ github.event_name == 'push' && 'Deploy to Test' || format('Deploy to {0}', github.event.inputs.environment) }}
 
 concurrency:

--- a/.github/workflows/deploy-env.yaml
+++ b/.github/workflows/deploy-env.yaml
@@ -45,6 +45,7 @@ jobs:
         uses: actions/checkout@v6.0.3
         with:
           ref: ${{ github.ref }}
+          persist-credentials: false
 
       - name: Lowercase Repository Name
         id: lowercase
@@ -85,6 +86,7 @@ jobs:
         uses: actions/checkout@v6.0.3
         with:
           ref: ${{ github.ref }}
+          persist-credentials: false
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v4

--- a/.github/workflows/deploy-github-documentation.yaml
+++ b/.github/workflows/deploy-github-documentation.yaml
@@ -16,6 +16,8 @@ jobs:
   build:
     name: Deploy docs
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout main
         uses: actions/checkout@v6.0.3

--- a/.github/workflows/deploy-github-documentation.yaml
+++ b/.github/workflows/deploy-github-documentation.yaml
@@ -10,6 +10,8 @@ on:
       - 'resources/tech_docs_template/**'
       - '.github/workflows/deploy-github-documentation.yaml'
 
+permissions: {}
+
 jobs:
   build:
     name: Deploy docs

--- a/.github/workflows/deploy-github-documentation.yaml
+++ b/.github/workflows/deploy-github-documentation.yaml
@@ -21,6 +21,8 @@ jobs:
     steps:
       - name: Checkout main
         uses: actions/checkout@v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Deploy docs
         uses: mhausenblas/mkdocs-deploy-gh-pages@master

--- a/.github/workflows/generate-documentation.yaml
+++ b/.github/workflows/generate-documentation.yaml
@@ -7,6 +7,8 @@ on:
   push:
     branches: [ "docs/**" ]
 
+permissions: {}
+
 jobs:
   generate-diagram:
     runs-on: ubuntu-latest

--- a/.github/workflows/generate-documentation.yaml
+++ b/.github/workflows/generate-documentation.yaml
@@ -16,6 +16,8 @@ jobs:
       contents: write
     steps:
       - name: Checkout Repository
+        with:
+          persist-credentials: false
         uses: actions/checkout@v6.0.3
       - uses: hashicorp/setup-terraform@v4
 

--- a/.github/workflows/generate-zap-scan.yaml
+++ b/.github/workflows/generate-zap-scan.yaml
@@ -27,6 +27,8 @@ jobs:
     steps:
       - name: "Checkout source"
         uses: actions/checkout@v6.0.3
+        with:
+          persist-credentials: false
 
       - name: "Az CLI login"
         uses: azure/login@v3

--- a/.github/workflows/generate-zap-scan.yaml
+++ b/.github/workflows/generate-zap-scan.yaml
@@ -12,9 +12,10 @@ on:
           - "elz-test"
           - "elz-staging"
           - "elz-production"
-
   schedule:
     - cron: "0 3 * * 1-5"
+      
+permissions: {}
 
 run-name: Running ZAP scan against ${{ github.event.inputs.environment || 'elz-staging'}}
 jobs:

--- a/.github/workflows/synchronise-contentful-environments.yml
+++ b/.github/workflows/synchronise-contentful-environments.yml
@@ -39,6 +39,7 @@ jobs:
         uses: actions/checkout@v6.0.3
         with:
           ref: ${{ github.ref }}
+          persist-credentials: false
 
       - name: Configure Runner Environment
         shell: bash

--- a/.github/workflows/synchronise-contentful-environments.yml
+++ b/.github/workflows/synchronise-contentful-environments.yml
@@ -27,6 +27,8 @@ on:
           - "Test"
           - "Development"
         default: "Development"
+        
+permissions: {}
 
 jobs:
   synchronise:

--- a/.github/workflows/tag-repository.yaml
+++ b/.github/workflows/tag-repository.yaml
@@ -11,6 +11,8 @@ jobs:
   tag_release:
     name: Create New Tag
     runs-on: ubuntu-latest
+    permissions: 
+      contents: write
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v6.0.3

--- a/.github/workflows/tag-repository.yaml
+++ b/.github/workflows/tag-repository.yaml
@@ -5,6 +5,8 @@ on:
     branches:
       - main
 
+permissions: {}
+
 jobs:
   tag_release:
     name: Create New Tag

--- a/.github/workflows/tag-repository.yaml
+++ b/.github/workflows/tag-repository.yaml
@@ -18,6 +18,7 @@ jobs:
         uses: actions/checkout@v6.0.3
         with:
           fetch-depth: 0
+          persist-credentials: false
           
       - name: Bump version and push tag
         id: tag_version

--- a/.github/workflows/validate-accessibility.yaml
+++ b/.github/workflows/validate-accessibility.yaml
@@ -24,6 +24,7 @@ jobs:
         uses: actions/checkout@v6.0.3
         with:
           ref: ${{ github.ref }}
+          persist-credentials: false
 
       - name: Setup Node.JS
         uses: actions/setup-node@v6

--- a/.github/workflows/validate-accessibility.yaml
+++ b/.github/workflows/validate-accessibility.yaml
@@ -13,6 +13,8 @@ on:
           - "staging"
           - "www"
 
+permissions: {}
+
 jobs:
   accessibility-scan:
     name: "Run Pa11y Accessibility Scan"

--- a/.github/workflows/validate-e2e.yaml
+++ b/.github/workflows/validate-e2e.yaml
@@ -19,6 +19,8 @@ jobs:
     name: Run Playwright Tests
     steps:
       - uses: actions/checkout@v6.0.3
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@v6
         with:
           node-version: "24"

--- a/.github/workflows/validate-e2e.yaml
+++ b/.github/workflows/validate-e2e.yaml
@@ -10,6 +10,8 @@ on:
       - ".github/workflows/validate-e2e.yaml"
   pull_request:
     branches: ["main"]
+    
+permissions: {}
 
 jobs:
   test:

--- a/.github/workflows/validate-links.yaml
+++ b/.github/workflows/validate-links.yaml
@@ -1,14 +1,17 @@
 name: Link Validation Check
-permissions:
-  contents: read
+
 on:
   workflow_dispatch:
   schedule:
     - cron: "00 02 * * 1-5"
+      
+permissions: {}
 
 jobs:
   scan-website-links:
     runs-on: ubuntu-latest
+    permissions: 
+      contents: read
     environment: elz-test
     env:
       WEBSITE_ROOT: ${{ vars.APP_WEBSITE_ROOT }}

--- a/.github/workflows/validate-links.yaml
+++ b/.github/workflows/validate-links.yaml
@@ -18,6 +18,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6.0.3
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/validate-sonarcloud.yml
+++ b/.github/workflows/validate-sonarcloud.yml
@@ -36,6 +36,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.ref }}
+          persist-credentials: false
 
       - name: Setup .NET ${{ env.DOTNET_VERSION }}
         uses: actions/setup-dotnet@v5

--- a/.github/workflows/validate-sonarcloud.yml
+++ b/.github/workflows/validate-sonarcloud.yml
@@ -9,13 +9,11 @@ on:
     branches:
       - 'main'
 
+permissions: {}
+
 concurrency:
   group: '${{ github.workflow }}-${{ github.ref }}'
   cancel-in-progress: true
-
-permissions:
-  pull-requests: write
-  contents: read
 
 env:
   DOTNET_VERSION: '10.x'
@@ -26,6 +24,9 @@ jobs:
     if: ${{ github.actor != 'dependabot[bot]' }}
     name: Build, Test & Analyse
     runs-on: ubuntu-24.04
+    permissions: 
+      pull-requests: write
+      contents: read
     defaults:
       run:
         working-directory: './src'

--- a/.github/workflows/validate-web.yaml
+++ b/.github/workflows/validate-web.yaml
@@ -4,6 +4,8 @@ on:
   workflow_call:
   pull_request:
     branches: [ "main" ]
+    
+permissions: {}
 
 jobs:
   build-backend:

--- a/.github/workflows/validate-web.yaml
+++ b/.github/workflows/validate-web.yaml
@@ -13,6 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Setup Node.JS
         uses: actions/setup-node@v6


### PR DESCRIPTION
Ticket: [CL-467](https://dfedigital.atlassian.net/browse/CL-467)

This PR is one part of CL-467 where Zizmor Static Analysis recommends manually setting all permissions to None by default at the workflow level (which `permissions: {}`) does) and only giving permissions at the job level (where applicable) - principle of least privilege

This is necessary even on workflows with one job, or workflows that don't set any permissions, as if the permission block is omitted completely there are actually some default permissions that are open! https://docs.zizmor.sh/audits/#excessive-permissions

Also sets persist-credentials to false unless explicitly required (default is true!), to prevent accidental publishing of git credentials: https://docs.zizmor.sh/audits/#artipacked