### PR TITLE
ci(CL-467): Static Analysis (Template Injection) 

### DIFF
--- a/.github/actions/lowercase/action.yml
+++ b/.github/actions/lowercase/action.yml
@@ -18,5 +18,7 @@ runs:
       id: lowercase
       shell: bash
       run: |
-        LOWERCASED_VALUE=$(echo "${{ inputs.value }}" | tr '[:upper:]' '[:lower:]')
+        LOWERCASED_VALUE=$(echo "${VALUE}" | tr '[:upper:]' '[:lower:]')
         echo "lowercased_value=$LOWERCASED_VALUE" >> $GITHUB_OUTPUT
+      env:
+        VALUE: ${{ inputs.value }}

--- a/.github/actions/manage-storage-network-access/action.yml
+++ b/.github/actions/manage-storage-network-access/action.yml
@@ -21,10 +21,13 @@ runs:
       shell: bash
       run: |
         az storage account update \
-          --name ${{ inputs.storage_account_name }} \
-          --resource-group ${{ inputs.resource_group_name }} \
+          --name ${STORAGE_ACCOUNT_NAME} \
+          --resource-group ${RESOURCE_GROUP_NAME} \
           --public-network-access Enabled \
           --default-action Allow > /dev/null
+      env:
+        STORAGE_ACCOUNT_NAME: ${{ inputs.storage_account_name }}
+        RESOURCE_GROUP_NAME: ${{ inputs.resource_group_name }}
     
     - name: Disable Public Network Access to Storage Account
       if: ${{ inputs.enable_network_access == 'false' }}
@@ -34,9 +37,12 @@ runs:
           echo "Disabling public network access due to workflow failure or cancellation."
         fi
         az storage account update \
-          --name ${{ inputs.storage_account_name }} \
-          --resource-group ${{ inputs.resource_group_name }} \
+          --name ${STORAGE_ACCOUNT_NAME} \
+          --resource-group ${RESOURCE_GROUP_NAME} \
           --public-network-access Disabled > /dev/null
+      env:
+        STORAGE_ACCOUNT_NAME: ${{ inputs.storage_account_name }}
+        RESOURCE_GROUP_NAME: ${{ inputs.resource_group_name }}
     
     - name: Sleep for 30s
       shell: bash

--- a/.github/workflows/deploy-contentful-migrations.yml
+++ b/.github/workflows/deploy-contentful-migrations.yml
@@ -33,7 +33,9 @@ jobs:
         run: npm install -g contentful-cli
 
       - name: Login to Contentful with management token
-        run: contentful login --management-token "${{ secrets.CONTENTFUL_MANAGEMENT_TOKEN }}"
+        run: contentful login --management-token "${CONTENTFUL_MANAGEMENT_TOKEN}"
+        env:
+          CONTENTFUL_MANAGEMENT_TOKEN: ${{ secrets.CONTENTFUL_MANAGEMENT_TOKEN }}
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v5

--- a/.github/workflows/deploy-env.yaml
+++ b/.github/workflows/deploy-env.yaml
@@ -52,7 +52,9 @@ jobs:
 
       - name: Build Web Docker Image
         run: |
-          docker build . -t ghcr.io/${{ steps.lowercase.outputs.lowercased_value }}:${{ env.TAG_NAME }} -f web/CareLeavers.Web/Dockerfile
+          docker build . -t ${TAG} -f web/CareLeavers.Web/Dockerfile
+        env:
+          TAG: ghcr.io/${{ steps.lowercase.outputs.lowercased_value }}:${{ env.TAG_NAME }}
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v4
@@ -63,7 +65,9 @@ jobs:
 
       - name: Push Web Docker Image
         run: |
-          docker push ghcr.io/${{ steps.lowercase.outputs.lowercased_value }}:${{ env.TAG_NAME }}
+          docker push ${TAG}
+        env:
+          TAG: ghcr.io/${{ steps.lowercase.outputs.lowercased_value }}:${{ env.TAG_NAME }}
 
   deploy:
     name: Deploying to ${{ github.event_name == 'push' && 'elz-test' || github.event.inputs.environment }}
@@ -130,8 +134,8 @@ jobs:
         working-directory: ./src/infrastructure/terraform
         run: |
           terraform init \
-            -backend-config="resource_group_name=${{ env.ENVIRONMENT_PREFIX }}rg-uks-cl-tfstate" \
-            -backend-config="storage_account_name=${{ env.ENVIRONMENT_PREFIX }}cltfstate" \
+            -backend-config="resource_group_name=${ENVIRONMENT_PREFIX}rg-uks-cl-tfstate" \
+            -backend-config="storage_account_name=${ENVIRONMENT_PREFIX}cltfstate" \
             -backend-config="container_name=tfstate" \
             -backend-config="key=terraform.tfstate"
 
@@ -139,8 +143,9 @@ jobs:
         id: terraform_plan
         working-directory: ./src/infrastructure/terraform
         run: |
-          terraform plan -out plan.plan -var-file="env_vars/${{ github.event_name == 'push' && 'elz-test' || github.event.inputs.environment }}.tfvars"
+          terraform plan -out plan.plan -var-file="env_vars/${ENVIRONMENT}.tfvars"
         env:
+          ENVIRONMENT: ${{ github.event_name == 'push' && 'elz-test' || github.event.inputs.environment }}
           TF_VAR_contentful_delivery_api_key: ${{ secrets.CONTENTFUL_DELIVERY_API_KEY }}
           TF_VAR_contentful_preview_api_key: ${{ secrets.CONTENTFUL_PREVIEW_API_KEY }}
           TF_VAR_contentful_management_api_key: ${{ secrets.CONTENTFUL_MANAGEMENT_TOKEN }}
@@ -174,14 +179,16 @@ jobs:
       - name: Swap Slot to Production
         if: github.event.inputs.environment == 'elz-production'
         run: |
-          az webapp deployment slot swap --name ${{ env.ENVIRONMENT_PREFIX }}-uks-cl-web-app-service --resource-group ${{ env.ENVIRONMENT_PREFIX }}rg-uks-cl-web --slot staging --target-slot production
+          az webapp deployment slot swap --name ${ENVIRONMENT_PREFIX}-uks-cl-web-app-service --resource-group ${ENVIRONMENT_PREFIX}rg-uks-cl-web --slot staging --target-slot production
 
       - name: Delete Staging Slot
         if: github.event.inputs.environment == 'elz-production'
         run: |
-          az webapp deployment slot delete --name ${{ env.ENVIRONMENT_PREFIX }}-uks-cl-web-app-service --resource-group ${{ env.ENVIRONMENT_PREFIX }}rg-uks-cl-web --slot staging
+          az webapp deployment slot delete --name ${ENVIRONMENT_PREFIX}-uks-cl-web-app-service --resource-group ${ENVIRONMENT_PREFIX}rg-uks-cl-web --slot staging
 
       - name: Clear Cache
         shell: bash
         run: |
-          curl -X POST "https://${{ vars.CUSTOM_DOMAIN }}/b0e0dce2-b96d-4b94-a800-63c3ab56e72f"
+          curl -X POST "https://${CUSTOM_DOMAIN}/b0e0dce2-b96d-4b94-a800-63c3ab56e72f"
+        env:
+          CUSTOM_DOMAIN: ${{ vars.CUSTOM_DOMAIN }}

--- a/.github/workflows/generate-documentation.yaml
+++ b/.github/workflows/generate-documentation.yaml
@@ -21,10 +21,10 @@ jobs:
         env:
           TERRAFORM_DOCS_VERSION: 0.18.0
         run: |
-          wget https://github.com/terraform-docs/terraform-docs/releases/download/v${{ env.TERRAFORM_DOCS_VERSION }}/terraform-docs-v${{ env.TERRAFORM_DOCS_VERSION }}-linux-amd64.tar.gz
-          tar -xvf terraform-docs-v${{ env.TERRAFORM_DOCS_VERSION }}-linux-amd64.tar.gz terraform-docs
+          wget https://github.com/terraform-docs/terraform-docs/releases/download/v${TERRAFORM_DOCS_VERSION}/terraform-docs-v${TERRAFORM_DOCS_VERSION}-linux-amd64.tar.gz
+          tar -xvf terraform-docs-v${TERRAFORM_DOCS_VERSION}-linux-amd64.tar.gz terraform-docs
           sudo mv terraform-docs /usr/local/bin/
-          rm terraform-docs-v${{ env.TERRAFORM_DOCS_VERSION }}-linux-amd64.tar.gz
+          rm terraform-docs-v${TERRAFORM_DOCS_VERSION}-linux-amd64.tar.gz
 
       - name: Terraform fmt
         id: fmt

--- a/.github/workflows/generate-zap-scan.yaml
+++ b/.github/workflows/generate-zap-scan.yaml
@@ -41,11 +41,13 @@ jobs:
       - name: Get Azure Frontdoor URL
         run: |
           FRONTDOOR_URL=$(az afd custom-domain list \
-            -g s272${{ vars.ENVIRONMENT_PREFIX }}rg-uks-cl-web \
-            --profile-name s272${{ vars.ENVIRONMENT_PREFIX }}-uks-cl-web-fd-profile \
+            -g s272${ENVIRONMENT_PREFIX}rg-uks-cl-web \
+            --profile-name s272${ENVIRONMENT_PREFIX}-uks-cl-web-fd-profile \
             --query "[0].hostName" -o tsv)
 
           echo "FRONTDOOR_URL=$FRONTDOOR_URL" >> ${GITHUB_ENV}
+        env:
+          ENVIRONMENT_PREFIX: ${{ vars.ENVIRONMENT_PREFIX }}
 
       - name: "Running ZAP scan against https://${{ env.FRONTDOOR_URL }}"
         uses: zaproxy/action-full-scan@3c58388149901b9a03b7718852c5ba889646c27c
@@ -75,9 +77,11 @@ jobs:
           if [ -f ./zap-report/report_md.md ]; then
             echo "## 🛡️ ZAP Security Scan Summary" >> $GITHUB_STEP_SUMMARY
             echo "⚠️ **Full report exceeds 1MB limit.**" >> $GITHUB_STEP_SUMMARY
-            echo "[Download Full Report from Artifacts](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})" >> $GITHUB_STEP_SUMMARY
+            echo "[Download Full Report from Artifacts](${FULL_REPORT_URL})" >> $GITHUB_STEP_SUMMARY
             echo "---" >> $GITHUB_STEP_SUMMARY
             grep -A 20 "Alerts" ./zap-report/report_md.md >> $GITHUB_STEP_SUMMARY
           else
             echo "⚠️ ZAP report_md.md not found." >> $GITHUB_STEP_SUMMARY
           fi
+        env:
+          FULL_REPORT_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/synchronise-contentful-environments.yml
+++ b/.github/workflows/synchronise-contentful-environments.yml
@@ -58,8 +58,8 @@ jobs:
           echo SPACE_ID=$CONTENTFUL_SPACE_ID >> .env
           echo MANAGEMENT_TOKEN=$CONTENTFUL_MANAGEMENT_TOKEN >> .env
           echo MIGRATION_TRACKER_ENTITY_ID=$CONTENTFUL_MIGRATION_TRACKER_ENTITY_ID >> .env
-          echo SOURCE_ENVIRONMENT=${{ env.SOURCE }} >> .env
-          echo TARGET_ENVIRONMENT=${{ env.TARGET }} >> .env
+          echo SOURCE_ENVIRONMENT=$SOURCE >> .env
+          echo TARGET_ENVIRONMENT=$TARGET >> .env
         env:
           CONTENTFUL_SPACE_ID: ${{ secrets.CONTENTFUL_SPACE_ID }}
           CONTENTFUL_MANAGEMENT_TOKEN: ${{ secrets.CONTENTFUL_MANAGEMENT_TOKEN }}

--- a/.github/workflows/validate-accessibility.yaml
+++ b/.github/workflows/validate-accessibility.yaml
@@ -32,4 +32,6 @@ jobs:
         working-directory: ./src/e2e/pa11y
         run: |
           yarn install --immutable --immutable-cache --production=true
-          yarn pa11y-ci --config pa11y.json --sitemap https://${{ github.event.inputs.domain_prefix }}.support-for-care-leavers.education.gov.uk/sitemap.xml
+          yarn pa11y-ci --config pa11y.json --sitemap https://${DOMAIN_PREFIX}.support-for-care-leavers.education.gov.uk/sitemap.xml
+        env:
+          DOMAIN_PREFIX: ${{ github.event.inputs.domain_prefix }}

--- a/.github/workflows/validate-sonarcloud.yml
+++ b/.github/workflows/validate-sonarcloud.yml
@@ -60,11 +60,14 @@ jobs:
           dotnet-sonarscanner begin \
           /o:"dfe-digital" \
           /k:"DFE-Digital_care-leavers" \
-          /d:sonar.token="${{ secrets.SONAR_TOKEN }}" \
+          /d:sonar.token="${SONAR_TOKEN}" \
           /d:sonar.coverage.exclusions=**/Program.cs,**/LoggingConfigurationExtensions.cs,**/esbuild.config.js,**.cshtml,**/Configuration/**,**/e2e/**,**/contentful/Synchronisation/**,**/utilities/**,**/Migrations/** \
           /d:sonar.exclusions=**/Program.cs,**/LoggingConfigurationExtensions.cs,**/Migrations/** \
           /d:sonar.scanner.skipJreProvisioning=true \
-          /s:${{ github.workspace }}/SonarQube.Analysis.xml
+          /s:${GITHUB_WORKSPACE}/SonarQube.Analysis.xml
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          GITHUB_WORKSPACE: ${{ github.workspace }}
 
       - name: Restore Solution
         shell: bash
@@ -102,7 +105,9 @@ jobs:
         shell: bash
         run: |
           dotnet-sonarscanner end \
-          /d:sonar.token="${{ secrets.SONAR_TOKEN }}"
+          /d:sonar.token="${SONAR_TOKEN}"
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
       - name: Generate Test Report
         uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2


### PR DESCRIPTION
Ticket:

This PR resolves all the template injection warnings from Zizmor - basically, `run` blocks (especially) do not sanitise inputs, so doing `${{ inputs.environment }}` or `${{ vars.EXAMPLE }}` etc can theoretically be injected with code, that if left inside a run block as-is will execute (especially bad for `inputs.x`) - https://docs.zizmor.sh/audits/#template-injection

To resolve, you set it in the environment variables first (mostly this is per-step `env`, which is also more secure too) as these do sanitise the inputs. We then reference it with standard bash `$EXAMPLE` / `${EXAMPLE}` in the `run` block (for Bash)